### PR TITLE
feat: strengthen EF-Sinn conversion and local SEO

### DIFF
--- a/about.html
+++ b/about.html
@@ -63,7 +63,7 @@
                 </ul>
                 <div class="nav-actions" aria-label="Schnellkontakt">
                     <a href="tel:+4917687186451" class="nav-phone" aria-label="ef-sinn telefonisch kontaktieren">+49 176 8718 6451</a>
-                    <a href="contact.html" class="nav-cta">Kostenlose Erstberatung</a>
+                    <a href="contact.html#anfrage-assistent" class="nav-cta">Kostenlose Erstberatung</a>
                 </div>
             </div>
         </nav>
@@ -214,7 +214,7 @@
             <p class="cta-text" data-i18n="about.cta.text">
                 Besuchen Sie unsere Werkstatt oder vereinbaren Sie einen Beratungstermin.
             </p>
-            <a href="contact.html" class="btn btn-secondary" data-i18n="cta.contact_now">Jetzt Kontakt aufnehmen</a>
+            <a href="contact.html#anfrage-assistent" class="btn btn-secondary" data-i18n="cta.contact_now">Jetzt Kontakt aufnehmen</a>
         </div>
     </section>
 
@@ -237,6 +237,7 @@
                         <li><a href="index.html" data-i18n="nav.home">Start</a></li>
                         <li><a href="about.html" data-i18n="nav.about">Über uns</a></li>
                         <li><a href="portfolio.html" data-i18n="nav.portfolio">Portfolio</a></li>
+                        <li><a href="schreiner-muenchen.html">Schreiner München</a></li>
                         <li><a href="contact.html" data-i18n="nav.contact">Kontakt</a></li>
                     </ul>
                 </div>

--- a/assets/js/i18n.js
+++ b/assets/js/i18n.js
@@ -19,7 +19,7 @@
 
   function load(lang,cb){
     var x=new XMLHttpRequest();
-    x.open('GET',prefix()+'i18n/'+lang+'.json?v='+Date.now());
+    x.open('GET',prefix()+'i18n/'+lang+'.json?v=20260520');
     x.onload=function(){if(x.status===200){try{cb(JSON.parse(x.responseText))}catch(e){cb({})}}else cb({})};
     x.onerror=function(){cb({})};
     x.send();

--- a/contact.html
+++ b/contact.html
@@ -67,7 +67,7 @@
                 </ul>
                 <div class="nav-actions" aria-label="Schnellkontakt">
                     <a href="tel:+4917687186451" class="nav-phone" aria-label="ef-sinn telefonisch kontaktieren">+49 176 8718 6451</a>
-                    <a href="contact.html" class="nav-cta">Kostenlose Erstberatung</a>
+                    <a href="contact.html#anfrage-assistent" class="nav-cta">Kostenlose Erstberatung</a>
                 </div>
             </div>
         </nav>
@@ -145,6 +145,11 @@
                         <p class="section-kicker">Schnelle Projektanfrage</p>
                         <h2 class="section-title" data-i18n="contact.write.title">Anfrage per E-Mail vorbereiten</h2>
                         <p class="inquiry-note">Füllen Sie kurz aus, worum es geht. Die Webseite speichert nichts und sendet nichts automatisch. Beim Klick öffnet sich nur Ihr E-Mail-Programm mit einer vorbereiteten Nachricht.</p>
+                        <ul class="inquiry-checklist" aria-label="Was für die erste Einschätzung hilft">
+                            <li>Maße oder grobe Raumgröße</li>
+                            <li>Ort oder Stadtteil im Großraum München</li>
+                            <li>Fotos können Sie danach in der E-Mail anhängen</li>
+                        </ul>
 
                         <label for="inq-name">Name</label>
                         <input id="inq-name" name="name" type="text" autocomplete="name" placeholder="Ihr Name">
@@ -182,8 +187,8 @@
                         <label for="inq-message">Kurze Beschreibung</label>
                         <textarea id="inq-message" name="message" rows="5" placeholder="Was soll gebaut, repariert oder geplant werden? Maße, Materialwunsch oder Fotos können Sie danach in der E-Mail anhängen."></textarea>
 
-                        <button type="submit" class="btn btn-secondary btn-full">Anfrage per E-Mail vorbereiten</button>
-                        <p class="inquiry-note small">Für Fotos: Nach dem Öffnen der E-Mail einfach Bilder als Anhang hinzufügen. Alternativ direkt anrufen: <a href="tel:+4917687186451">+49 176 8718 6451</a>.</p>
+                        <button type="submit" class="btn btn-secondary btn-full">E-Mail mit Anfrage öffnen</button>
+                        <p class="inquiry-note small">Für Fotos: Nach dem Öffnen der E-Mail einfach Bilder als Anhang hinzufügen. Falls sich kein E-Mail-Programm öffnet, kopieren Sie die Angaben und senden Sie sie an <a href="mailto:info@ef-sinn.de">info@ef-sinn.de</a> oder rufen Sie direkt an: <a href="tel:+4917687186451">+49 176 8718 6451</a>.</p>
                     </form>
                 </div>
             </div>
@@ -240,6 +245,7 @@
                         <li><a href="index.html" data-i18n="nav.home">Start</a></li>
                         <li><a href="about.html" data-i18n="nav.about">Über uns</a></li>
                         <li><a href="portfolio.html" data-i18n="nav.portfolio">Portfolio</a></li>
+                        <li><a href="schreiner-muenchen.html">Schreiner München</a></li>
                         <li><a href="contact.html" data-i18n="nav.contact">Kontakt</a></li>
                     </ul>
                 </div>

--- a/datenschutz.html
+++ b/datenschutz.html
@@ -6,6 +6,7 @@
     <link rel="icon" type="image/x-icon" href="favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="assets/apple-touch-icon.png">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="canonical" href="https://www.ef-sinn.de/datenschutz.html">
     <meta name="description" content="Datenschutzerklärung von ef-sinn - Informationen zur Datenverarbeitung gemäß DSGVO">
     <title>Datenschutzerklärung - ef-sinn</title>
     <link rel="stylesheet" href="styles.css">
@@ -26,7 +27,7 @@
                 </ul>
                 <div class="nav-actions" aria-label="Schnellkontakt">
                     <a href="tel:+4917687186451" class="nav-phone" aria-label="ef-sinn telefonisch kontaktieren">+49 176 8718 6451</a>
-                    <a href="contact.html" class="nav-cta">Kostenlose Erstberatung</a>
+                    <a href="contact.html#anfrage-assistent" class="nav-cta">Kostenlose Erstberatung</a>
                 </div>
             </div>
         </nav>
@@ -242,7 +243,7 @@
             </p>
 
             <p style="margin-top: 3rem; padding-top: 2rem; border-top: 1px solid var(--color-border); color: var(--color-text-light); font-size: 0.875rem;">
-                Quelle: <a href="https://www.e-recht24.de" target="_blank" style="color: var(--color-primary);">e-recht24.de</a><br>
+                Quelle: <a href="https://www.e-recht24.de" target="_blank" style="color: var(--color-primary);" rel="noopener noreferrer">e-recht24.de</a><br>
                 Letzte Aktualisierung: 19.05.2026
             </p>
 
@@ -269,6 +270,7 @@
                         <li><a href="index.html" data-i18n="nav.home">Start</a></li>
                         <li><a href="about.html" data-i18n="nav.about">Über uns</a></li>
                         <li><a href="portfolio.html" data-i18n="nav.portfolio">Portfolio</a></li>
+                        <li><a href="schreiner-muenchen.html">Schreiner München</a></li>
                         <li><a href="contact.html" data-i18n="nav.contact">Kontakt</a></li>
                     </ul>
                 </div>

--- a/impressum.html
+++ b/impressum.html
@@ -6,6 +6,7 @@
     <link rel="icon" type="image/x-icon" href="favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="assets/apple-touch-icon.png">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="canonical" href="https://www.ef-sinn.de/impressum.html">
     <meta name="description" content="Impressum von ef-sinn - Gesetzliche Angaben gemäß § 5 TMG">
     <title>Impressum - ef-sinn</title>
     <link rel="stylesheet" href="styles.css">
@@ -26,7 +27,7 @@
                 </ul>
                 <div class="nav-actions" aria-label="Schnellkontakt">
                     <a href="tel:+4917687186451" class="nav-phone" aria-label="ef-sinn telefonisch kontaktieren">+49 176 8718 6451</a>
-                    <a href="contact.html" class="nav-cta">Kostenlose Erstberatung</a>
+                    <a href="contact.html#anfrage-assistent" class="nav-cta">Kostenlose Erstberatung</a>
                 </div>
             </div>
         </nav>
@@ -59,12 +60,12 @@
             <h3 style="color: var(--color-primary); margin-bottom: 0.5rem; margin-top: 2rem;">Berufsbezeichnung und berufsrechtliche Regelungen</h3>
             <p style="margin-bottom: 2rem; line-height: 1.8;">
                 Berufsbezeichnung: Schreiner (Geselle)<br>
-                Zuständige Kammer: <a href="https://www.hwk-muenchen.de" target="_blank" style="color: var(--color-primary);">Handwerkskammer für München und Oberbayern</a>
+                Zuständige Kammer: <a href="https://www.hwk-muenchen.de" target="_blank" style="color: var(--color-primary);" rel="noopener noreferrer">Handwerkskammer für München und Oberbayern</a>
             </p>
 
             <h3 style="color: var(--color-primary); margin-bottom: 0.5rem; margin-top: 2rem;">Berufsgenossenschaft</h3>
             <p style="margin-bottom: 2rem; line-height: 1.8;">
-                <a href="https://www.bghm.de" target="_blank" style="color: var(--color-primary);">Berufsgenossenschaft Holz und Metall (BGHM)</a>
+                <a href="https://www.bghm.de" target="_blank" style="color: var(--color-primary);" rel="noopener noreferrer">Berufsgenossenschaft Holz und Metall (BGHM)</a>
             </p>
 
             <h3 style="color: var(--color-primary); margin-bottom: 0.5rem; margin-top: 2rem;">Steuerliche Angaben</h3>
@@ -76,7 +77,7 @@
             <h3 style="color: var(--color-primary); margin-bottom: 0.5rem; margin-top: 2rem;">EU-Streitschlichtung</h3>
             <p style="margin-bottom: 2rem; line-height: 1.8;">
                 Die Europäische Kommission stellt eine Plattform zur Online-Streitbeilegung (OS) bereit: 
-                <a href="https://ec.europa.eu/consumers/odr/" target="_blank" style="color: var(--color-primary);">https://ec.europa.eu/consumers/odr/</a>.<br>
+                <a href="https://ec.europa.eu/consumers/odr/" target="_blank" style="color: var(--color-primary);" rel="noopener noreferrer">https://ec.europa.eu/consumers/odr/</a>.<br>
                 Unsere E-Mail-Adresse finden Sie oben im Impressum.
             </p>
 
@@ -125,7 +126,7 @@
             </p>
 
             <p style="margin-top: 3rem; padding-top: 2rem; border-top: 1px solid var(--color-border); color: var(--color-text-light); font-size: 0.875rem;">
-                Quelle: <a href="https://www.e-recht24.de" target="_blank" style="color: var(--color-primary);">e-recht24.de</a>
+                Quelle: <a href="https://www.e-recht24.de" target="_blank" style="color: var(--color-primary);" rel="noopener noreferrer">e-recht24.de</a>
             </p>
 
         </div>
@@ -151,6 +152,7 @@
                         <li><a href="index.html" data-i18n="nav.home">Start</a></li>
                         <li><a href="about.html" data-i18n="nav.about">Über uns</a></li>
                         <li><a href="portfolio.html" data-i18n="nav.portfolio">Portfolio</a></li>
+                        <li><a href="schreiner-muenchen.html">Schreiner München</a></li>
                         <li><a href="contact.html" data-i18n="nav.contact">Kontakt</a></li>
                     </ul>
                 </div>

--- a/index.html
+++ b/index.html
@@ -298,7 +298,7 @@
                 </ul>
                 <div class="nav-actions" aria-label="Schnellkontakt">
                     <a href="tel:+4917687186451" class="nav-phone" aria-label="ef-sinn telefonisch kontaktieren">+49 176 8718 6451</a>
-                    <a href="contact.html" class="nav-cta">Kostenlose Erstberatung</a>
+                    <a href="contact.html#anfrage-assistent" class="nav-cta">Kostenlose Erstberatung</a>
                 </div>
             </div>
         </nav>
@@ -313,9 +313,9 @@
             <p class="hero-subtitle fade-in-delay"> <span data-i18n="home.hero.subtitle">Handwerkliche Maßarbeit aus Holz — persönlich geplant, sauber gebaut und zuverlässig montiert.</span></p>
             <div class="hero-actions fade-in-delay-2">
                 <a href="contact.html#anfrage-assistent" class="btn btn-primary"> <span data-i18n="home.hero.cta">Kostenlose Erstberatung anfragen</span></a>
-                <a href="portfolio.html" class="btn btn-ghost-light">Arbeiten ansehen</a>
-                <a href="schreiner-muenchen.html" class="btn btn-ghost-light">Schreiner München</a>
+                <a href="tel:+4917687186451" class="btn btn-ghost-light">Direkt anrufen</a>
             </div>
+            <p class="hero-microcopy">Kurze Beschreibung und Fotos reichen für eine erste Einschätzung. <a href="schreiner-muenchen.html">Mehr zu Schreinerarbeiten in München</a>.</p>
             <div class="hero-trust" aria-label="Stärken von ef-sinn">
                 <span>✓ Persönliche Beratung</span>
                 <span>✓ Maßgefertigt in München</span>
@@ -740,7 +740,7 @@
         <div class="container">
             <h2 class="cta-title" data-i18n="home.cta.title">Bereit für Ihr individuelles Projekt?</h2>
             <p class="cta-text" data-i18n="home.cta.text">Lassen Sie uns gemeinsam Ihre Ideen in handwerkliche Realität umsetzen.</p>
-            <a href="contact.html" class="btn btn-secondary" data-i18n="cta.contact_now">Jetzt Kontakt aufnehmen</a>
+            <a href="contact.html#anfrage-assistent" class="btn btn-secondary" data-i18n="cta.contact_now">Jetzt Kontakt aufnehmen</a>
         </div>
     </section>
 
@@ -763,6 +763,7 @@
                         <li><a href="index.html" data-i18n="nav.home">Start</a></li>
                         <li><a href="about.html" data-i18n="nav.about">Über uns</a></li>
                         <li><a href="portfolio.html" data-i18n="nav.portfolio">Portfolio</a></li>
+                        <li><a href="schreiner-muenchen.html">Schreiner München</a></li>
                         <li><a href="contact.html" data-i18n="nav.contact">Kontakt</a></li>
                     </ul>
                 </div>

--- a/leistungen/innenausbau.html
+++ b/leistungen/innenausbau.html
@@ -21,11 +21,7 @@
       "@type": "Service",
       "name": "Parkettboden & Innenausbau",
       "description": "Parkettboden verlegen, schleifen und versiegeln. Kompletter Innenausbau mit Holz – Holzdecken, Wandverkleidungen und mehr.",
-      "provider": {
-        "@type": "LocalBusiness",
-        "name": "ef-sinn",
-        "url": "https://www.ef-sinn.de"
-      },
+      "provider": {"@id": "https://www.ef-sinn.de/#business"},
       "areaServed": {"@type": "City", "name": "München"}
     }
     </script>
@@ -46,7 +42,7 @@
                 </ul>
                 <div class="nav-actions" aria-label="Schnellkontakt">
                     <a href="tel:+4917687186451" class="nav-phone" aria-label="ef-sinn telefonisch kontaktieren">+49 176 8718 6451</a>
-                    <a href="../contact.html" class="nav-cta">Kostenlose Erstberatung</a>
+                    <a href="../contact.html#anfrage-assistent" class="nav-cta">Kostenlose Erstberatung</a>
                 </div>
             </div>
         </nav>
@@ -217,7 +213,7 @@
             <p class="cta-text">
                 <span data-i18n="innenausbau.cta.text">Lassen Sie uns über Ihren Parkettboden oder Innenausbau sprechen – wir beraten Sie gerne.</span>
             </p>
-            <a href="../contact.html" class="btn btn-secondary"><span data-i18n="innenausbau.cta.btn">Beratung anfragen</span></a>
+            <a href="../contact.html#anfrage-assistent" class="btn btn-secondary"><span data-i18n="innenausbau.cta.btn">Beratung anfragen</span></a>
         </div>
     </section>
 
@@ -261,6 +257,7 @@
                         <li><a href="../index.html" data-i18n="nav.home">Start</a></li>
                         <li><a href="../about.html" data-i18n="nav.about">Über uns</a></li>
                         <li><a href="../portfolio.html" data-i18n="nav.portfolio">Portfolio</a></li>
+                        <li><a href="../schreiner-muenchen.html">Schreiner München</a></li>
                         <li><a href="../contact.html" data-i18n="nav.contact">Kontakt</a></li>
                     </ul>
                 </div>

--- a/leistungen/kuechen.html
+++ b/leistungen/kuechen.html
@@ -13,7 +13,7 @@
     <meta property="og:description" content="Maßgefertigte Einbauküchen und Schranklösungen vom Schreiner in München. Individuelle Planung und höchste Qualität.">
     <meta property="og:url" content="https://www.ef-sinn.de/leistungen/kuechen.html">
     <meta property="og:locale" content="de_DE">
-    <title>Küchen & Schränke – ef-sinn Schreiner Werkstatt München | Einbauküchen nach Maß</title>
+    <title>Küche nach Maß München | Schreinerküchen & Schränke – ef-sinn</title>
     <link rel="stylesheet" href="../styles.css">
     <script type="application/ld+json">
     {
@@ -21,11 +21,7 @@
       "@type": "Service",
       "name": "Küchen & Schränke nach Maß",
       "description": "Maßgefertigte Einbauküchen und Schranklösungen mit individueller Planung und höchster handwerklicher Qualität.",
-      "provider": {
-        "@type": "LocalBusiness",
-        "name": "ef-sinn",
-        "url": "https://www.ef-sinn.de"
-      },
+      "provider": {"@id": "https://www.ef-sinn.de/#business"},
       "areaServed": {"@type": "City", "name": "München"}
     }
     </script>
@@ -46,7 +42,7 @@
                 </ul>
                 <div class="nav-actions" aria-label="Schnellkontakt">
                     <a href="tel:+4917687186451" class="nav-phone" aria-label="ef-sinn telefonisch kontaktieren">+49 176 8718 6451</a>
-                    <a href="../contact.html" class="nav-cta">Kostenlose Erstberatung</a>
+                    <a href="../contact.html#anfrage-assistent" class="nav-cta">Kostenlose Erstberatung</a>
                 </div>
             </div>
         </nav>
@@ -139,7 +135,7 @@
             <p class="cta-text">
                 Lassen Sie uns gemeinsam Ihre perfekte Küche planen – individuell, hochwertig und auf Maß.
             </p>
-            <a href="../contact.html" class="btn btn-secondary"><span data-i18n="kuechen.cta.btn">Küchenberatung anfragen</span></a>
+            <a href="../contact.html#anfrage-assistent" class="btn btn-secondary"><span data-i18n="kuechen.cta.btn">Küchenberatung anfragen</span></a>
         </div>
     </section>
 
@@ -183,6 +179,7 @@
                         <li><a href="../index.html" data-i18n="nav.home">Start</a></li>
                         <li><a href="../about.html" data-i18n="nav.about">Über uns</a></li>
                         <li><a href="../portfolio.html" data-i18n="nav.portfolio">Portfolio</a></li>
+                        <li><a href="../schreiner-muenchen.html">Schreiner München</a></li>
                         <li><a href="../contact.html" data-i18n="nav.contact">Kontakt</a></li>
                     </ul>
                 </div>

--- a/leistungen/moebelbau.html
+++ b/leistungen/moebelbau.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/x-icon" href="../favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="../assets/apple-touch-icon.png">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Möbelbau nach Maß von ef-sinn in München. Individuelle Massivholzmöbel – Tische, Betten, Regale, Sideboards, Kommoden und Sondermöbel. Persönliche Beratung & höchste Qualität.">
+    <meta name="description" content="Möbelbau nach Maß in München und Unterhaching: Einbauschränke, Tische, Regale, Badmöbel und Sonderlösungen vom Schreiner. Projekt unverbindlich anfragen.">
     <meta name="keywords" content="Möbelbau nach Maß München, Maßmöbel München, Massivholzmöbel München, Tisch nach Maß, Bett nach Maß, Regal nach Maß, Schreiner Möbelbau München">
     <link rel="canonical" href="https://www.ef-sinn.de/leistungen/moebelbau.html">
     <meta property="og:type" content="website">
@@ -14,7 +14,7 @@
     <meta property="og:url" content="https://www.ef-sinn.de/leistungen/moebelbau.html">
     <meta property="og:image" content="https://www.ef-sinn.de/bilder/portfolio/badmoebel-01.jpg">
     <meta property="og:locale" content="de_DE">
-    <title>Möbelbau nach Maß – ef-sinn Schreiner Werkstatt München | Individuelle Massivholzmöbel</title>
+    <title>Möbelbau München | Maßmöbel & Einbauschränke – ef-sinn</title>
     <link rel="stylesheet" href="../styles.css">
     <script type="application/ld+json">
     {
@@ -22,11 +22,7 @@
       "@type": "Service",
       "name": "Möbelbau nach Maß",
       "description": "Individuelle Massivholzmöbel nach Ihren Wünschen – Tische, Betten, Regale, Kommoden, Sideboards und Sondermöbel.",
-      "provider": {
-        "@type": "LocalBusiness",
-        "name": "ef-sinn",
-        "url": "https://www.ef-sinn.de"
-      },
+      "provider": {"@id": "https://www.ef-sinn.de/#business"},
       "areaServed": {"@type": "City", "name": "München"}
     }
     </script>
@@ -47,7 +43,7 @@
                 </ul>
                 <div class="nav-actions" aria-label="Schnellkontakt">
                     <a href="tel:+4917687186451" class="nav-phone" aria-label="ef-sinn telefonisch kontaktieren">+49 176 8718 6451</a>
-                    <a href="../contact.html" class="nav-cta">Kostenlose Erstberatung</a>
+                    <a href="../contact.html#anfrage-assistent" class="nav-cta">Kostenlose Erstberatung</a>
                 </div>
             </div>
         </nav>
@@ -164,7 +160,7 @@
             <p class="cta-text">
                 Erzählen Sie uns von Ihrem Projekt – wir beraten Sie persönlich und unverbindlich.
             </p>
-            <a href="../contact.html" class="btn btn-secondary"><span data-i18n="moebelbau.cta.btn">Jetzt Projekt besprechen</span></a>
+            <a href="../contact.html#anfrage-assistent" class="btn btn-secondary"><span data-i18n="moebelbau.cta.btn">Jetzt Projekt besprechen</span></a>
         </div>
     </section>
 
@@ -208,6 +204,7 @@
                         <li><a href="../index.html" data-i18n="nav.home">Start</a></li>
                         <li><a href="../about.html" data-i18n="nav.about">Über uns</a></li>
                         <li><a href="../portfolio.html" data-i18n="nav.portfolio">Portfolio</a></li>
+                        <li><a href="../schreiner-muenchen.html">Schreiner München</a></li>
                         <li><a href="../contact.html" data-i18n="nav.contact">Kontakt</a></li>
                     </ul>
                 </div>

--- a/leistungen/restaurierung.html
+++ b/leistungen/restaurierung.html
@@ -21,11 +21,7 @@
       "@type": "Service",
       "name": "Reparatur & Restaurierung",
       "description": "Fachgerechte Restaurierung antiker und wertvoller Möbelstücke sowie Reparatur von beschädigten Holzmöbeln.",
-      "provider": {
-        "@type": "LocalBusiness",
-        "name": "ef-sinn",
-        "url": "https://www.ef-sinn.de"
-      },
+      "provider": {"@id": "https://www.ef-sinn.de/#business"},
       "areaServed": {"@type": "City", "name": "München"}
     }
     </script>
@@ -46,7 +42,7 @@
                 </ul>
                 <div class="nav-actions" aria-label="Schnellkontakt">
                     <a href="tel:+4917687186451" class="nav-phone" aria-label="ef-sinn telefonisch kontaktieren">+49 176 8718 6451</a>
-                    <a href="../contact.html" class="nav-cta">Kostenlose Erstberatung</a>
+                    <a href="../contact.html#anfrage-assistent" class="nav-cta">Kostenlose Erstberatung</a>
                 </div>
             </div>
         </nav>
@@ -130,7 +126,7 @@
             <p class="cta-text">
                 Bringen Sie uns Ihr Möbelstück oder senden Sie uns Fotos – wir beraten Sie ehrlich und unverbindlich.
             </p>
-            <a href="../contact.html" class="btn btn-secondary"><span data-i18n="restaurierung.cta.btn">Restaurierung anfragen</span></a>
+            <a href="../contact.html#anfrage-assistent" class="btn btn-secondary"><span data-i18n="restaurierung.cta.btn">Restaurierung anfragen</span></a>
         </div>
     </section>
 
@@ -174,6 +170,7 @@
                         <li><a href="../index.html" data-i18n="nav.home">Start</a></li>
                         <li><a href="../about.html" data-i18n="nav.about">Über uns</a></li>
                         <li><a href="../portfolio.html" data-i18n="nav.portfolio">Portfolio</a></li>
+                        <li><a href="../schreiner-muenchen.html">Schreiner München</a></li>
                         <li><a href="../contact.html" data-i18n="nav.contact">Kontakt</a></li>
                     </ul>
                 </div>

--- a/leistungen/terrassen.html
+++ b/leistungen/terrassen.html
@@ -22,11 +22,7 @@
       "@type": "Service",
       "name": "Holzterrassen",
       "description": "Langlebige Holzterrassen und Holzdecks für den Garten, mit oder ohne Unterkonstruktion und Überdachung.",
-      "provider": {
-        "@type": "LocalBusiness",
-        "name": "ef-sinn",
-        "url": "https://www.ef-sinn.de"
-      },
+      "provider": {"@id": "https://www.ef-sinn.de/#business"},
       "areaServed": {"@type": "City", "name": "München"}
     }
     </script>
@@ -47,7 +43,7 @@
                 </ul>
                 <div class="nav-actions" aria-label="Schnellkontakt">
                     <a href="tel:+4917687186451" class="nav-phone" aria-label="ef-sinn telefonisch kontaktieren">+49 176 8718 6451</a>
-                    <a href="../contact.html" class="nav-cta">Kostenlose Erstberatung</a>
+                    <a href="../contact.html#anfrage-assistent" class="nav-cta">Kostenlose Erstberatung</a>
                 </div>
             </div>
         </nav>
@@ -272,7 +268,7 @@
             <p class="cta-text">
                 Planen Sie mit uns Ihre Traumterrasse – robust, langlebig und wunderschön.
             </p>
-            <a href="../contact.html" class="btn btn-secondary"><span data-i18n="terrassen.cta.btn">Terrassenberatung anfragen</span></a>
+            <a href="../contact.html#anfrage-assistent" class="btn btn-secondary"><span data-i18n="terrassen.cta.btn">Terrassenberatung anfragen</span></a>
         </div>
     </section>
 
@@ -316,6 +312,7 @@
                         <li><a href="../index.html" data-i18n="nav.home">Start</a></li>
                         <li><a href="../about.html" data-i18n="nav.about">Über uns</a></li>
                         <li><a href="../portfolio.html" data-i18n="nav.portfolio">Portfolio</a></li>
+                        <li><a href="../schreiner-muenchen.html">Schreiner München</a></li>
                         <li><a href="../contact.html" data-i18n="nav.contact">Kontakt</a></li>
                     </ul>
                 </div>

--- a/leistungen/treppen.html
+++ b/leistungen/treppen.html
@@ -22,11 +22,7 @@
       "@type": "Service",
       "name": "Holztreppen nach Maß",
       "description": "Hochwertige Holztreppen individuell gefertigt – gerade Treppen, Wendeltreppen, Podesttreppen und freitragende Konstruktionen.",
-      "provider": {
-        "@type": "LocalBusiness",
-        "name": "ef-sinn",
-        "url": "https://www.ef-sinn.de"
-      },
+      "provider": {"@id": "https://www.ef-sinn.de/#business"},
       "areaServed": {"@type": "City", "name": "München"}
     }
     </script>
@@ -47,7 +43,7 @@
                 </ul>
                 <div class="nav-actions" aria-label="Schnellkontakt">
                     <a href="tel:+4917687186451" class="nav-phone" aria-label="ef-sinn telefonisch kontaktieren">+49 176 8718 6451</a>
-                    <a href="../contact.html" class="nav-cta">Kostenlose Erstberatung</a>
+                    <a href="../contact.html#anfrage-assistent" class="nav-cta">Kostenlose Erstberatung</a>
                 </div>
             </div>
         </nav>
@@ -152,7 +148,7 @@
             <p class="cta-text">
                 Wir beraten Sie gerne zu den Möglichkeiten für Ihre neue Holztreppe.
             </p>
-            <a href="../contact.html" class="btn btn-secondary"><span data-i18n="treppen.cta.btn">Treppenberatung anfragen</span></a>
+            <a href="../contact.html#anfrage-assistent" class="btn btn-secondary"><span data-i18n="treppen.cta.btn">Treppenberatung anfragen</span></a>
         </div>
     </section>
 
@@ -196,6 +192,7 @@
                         <li><a href="../index.html" data-i18n="nav.home">Start</a></li>
                         <li><a href="../about.html" data-i18n="nav.about">Über uns</a></li>
                         <li><a href="../portfolio.html" data-i18n="nav.portfolio">Portfolio</a></li>
+                        <li><a href="../schreiner-muenchen.html">Schreiner München</a></li>
                         <li><a href="../contact.html" data-i18n="nav.contact">Kontakt</a></li>
                     </ul>
                 </div>

--- a/portfolio.html
+++ b/portfolio.html
@@ -774,7 +774,7 @@
                 </ul>
                 <div class="nav-actions" aria-label="Schnellkontakt">
                     <a href="tel:+4917687186451" class="nav-phone" aria-label="ef-sinn telefonisch kontaktieren">+49 176 8718 6451</a>
-                    <a href="contact.html" class="nav-cta">Kostenlose Erstberatung</a>
+                    <a href="contact.html#anfrage-assistent" class="nav-cta">Kostenlose Erstberatung</a>
                 </div>
             </div>
         </nav>
@@ -1544,7 +1544,7 @@
                     <span class="primary" data-i18n="portfolio.cta.hl2">✦ Individuelle Planung</span>
                     <span class="gold" data-i18n="portfolio.cta.hl3">✦ Präzise Ausführung</span>
                 </div>
-                <a href="contact.html" class="btn btn-primary" data-i18n="portfolio.cta.btn">Projekt besprechen</a>
+                <a href="contact.html#anfrage-assistent" class="btn btn-primary" data-i18n="portfolio.cta.btn">Projekt besprechen</a>
             </div>
         </div>
     </section>
@@ -1574,6 +1574,7 @@
                         <li><a href="index.html" data-i18n="nav.home">Start</a></li>
                         <li><a href="about.html" data-i18n="nav.about">Über uns</a></li>
                         <li><a href="portfolio.html" data-i18n="nav.portfolio">Portfolio</a></li>
+                        <li><a href="schreiner-muenchen.html">Schreiner München</a></li>
                         <li><a href="contact.html" data-i18n="nav.contact">Kontakt</a></li>
                     </ul>
                 </div>

--- a/schreiner-muenchen.html
+++ b/schreiner-muenchen.html
@@ -41,7 +41,7 @@
                 </ul>
                 <div class="nav-actions" aria-label="Schnellkontakt">
                     <a href="tel:+4917687186451" class="nav-phone" aria-label="ef-sinn telefonisch kontaktieren">+49 176 8718 6451</a>
-                    <a href="contact.html" class="nav-cta">Kostenlose Erstberatung</a>
+                    <a href="contact.html#anfrage-assistent" class="nav-cta">Kostenlose Erstberatung</a>
                 </div>
             </div>
         </nav>
@@ -154,7 +154,7 @@
         <div class="container">
             <div class="footer-grid">
                 <div class="footer-column"><h3 class="footer-title">ef-sinn</h3><p class="footer-text">Qualität und Handwerkskunst.<br>Ihr Partner für maßgefertigte Holzarbeiten.<br><br><strong>Büro:</strong> Schmorellstraße 6, 82008 Unterhaching<br><strong>Werkstatt:</strong> Germeringer Weg 3C, 81245 München</p></div>
-                <div class="footer-column"><h3 class="footer-title">Navigation</h3><ul class="footer-links"><li><a href="index.html">Start</a></li><li><a href="about.html">Über uns</a></li><li><a href="portfolio.html">Portfolio</a></li><li><a href="contact.html">Kontakt</a></li></ul></div>
+                <div class="footer-column"><h3 class="footer-title">Navigation</h3><ul class="footer-links"><li><a href="index.html">Start</a></li><li><a href="about.html">Über uns</a></li><li><a href="portfolio.html">Portfolio</a></li><li><a href="schreiner-muenchen.html">Schreiner München</a></li><li><a href="contact.html">Kontakt</a></li></ul></div>
                 <div class="footer-column"><h3 class="footer-title">Rechtliches</h3><ul class="footer-links"><li><a href="impressum.html">Impressum</a></li><li><a href="datenschutz.html">Datenschutz</a></li></ul></div>
             </div>
             <div class="footer-bottom"><p>© 2026 ef-sinn. Alle Rechte vorbehalten.</p></div>

--- a/styles.css
+++ b/styles.css
@@ -413,6 +413,21 @@ textarea {
     box-shadow: 0 8px 24px rgba(0,0,0,0.18);
 }
 
+
+.hero-microcopy {
+    max-width: 720px;
+    margin: -0.5rem auto 1.25rem;
+    color: rgba(255,255,255,0.94);
+    font-weight: 600;
+    text-shadow: 0 2px 12px rgba(0,0,0,0.35);
+}
+
+.hero-microcopy a {
+    color: #ffffff;
+    text-decoration: underline;
+    text-underline-offset: 0.2em;
+}
+
 /* Scroll Indicator */
 .scroll-indicator {
     position: absolute;
@@ -2415,4 +2430,24 @@ img {
     .project-template-grid {
         grid-template-columns: 1fr;
     }
+}
+
+#anfrage-assistent,
+.contact-form-wrapper {
+    scroll-margin-top: 7rem;
+}
+
+.inquiry-checklist {
+    margin: -0.25rem 0 1.25rem 1.2rem;
+    color: var(--color-text);
+    line-height: 1.7;
+}
+
+.inquiry-checklist li::marker {
+    color: var(--color-primary);
+}
+
+@supports (padding: env(safe-area-inset-bottom)) {
+  body { padding-bottom: calc(70px + env(safe-area-inset-bottom)); }
+  .mobile-contact-bar { padding-bottom: env(safe-area-inset-bottom); }
 }


### PR DESCRIPTION
## Zusammenfassung
- stärkt den Hero-Funnel: nur noch Erstberatung + Direktanruf, SEO-Link als Microcopy
- leitet Schnellkontakt-CTAs direkt zum Anfrage-Assistenten
- korrigiert klickbare Telefon-/JSON-LD-Telefone und härtet externe Links
- ergänzt lokale SEO-Verlinkung „Schreiner München" im Footer
- verbessert Kontakt-Assistent: Checkliste, mailto-Fallback, klarerer Button
- verbessert technische Basis: statischer i18n-Cache-Buster, Canonicals für Rechtliches, scroll-margin/safe-area für Mobile
- schärft drei Service-Seiten für lokale Suchintentionen und referenziert die Haupt-Business-Entität im Service-JSON-LD

## Verifikation
- JSON-LD parsebar auf allen HTML-Seiten
- lokale Links/Assets/Anker geprüft
- keine doppelten IDs
- `target="_blank"` Links mit `rel="noopener noreferrer"`
- lokale HTTP-Checks: Start, Kontakt, Portfolio, Schreiner München, Service, Impressum, Datenschutz, Sitemap, Robots → 200
- `node -c assets/js/i18n.js`
- Browser-Konsole lokal: Startseite und Kontaktseite ohne JavaScript-Fehler

## Hinweis
`assets/js/page-flip.browser.js` war vorher untracked und bleibt bewusst außerhalb des Commits.
