### PR TITLE
fix: simplify portfolio category filtering

### DIFF
--- a/i18n/de-AT.json
+++ b/i18n/de-AT.json
@@ -538,8 +538,8 @@
   "nav.callAria": "ef-sinn telefonisch kontaktieren",
   "mobile.quickContact": "Schnellkontakt mobil",
   "portfolio.search.kicker": "Referenzsuche",
-  "portfolio.search.title": "Welches Projekt suchen Sie?",
-  "portfolio.search.text": "Suchen Sie nach Möbelbau, Einbauschrank, Badmöbel, Parkett, Terrasse, Treppe oder München. Die Projektkarten zeigen passende Beispiele und führen direkt zur Anfrage.",
+  "portfolio.search.title": "Welche Kategorie suchen Sie?",
+  "portfolio.search.text": "Wählen Sie eine feste Kategorie. Die Seite zeigt dann alle passenden Referenzen — ohne freie Texteingabe und ohne doppelte Kategorie-Buttons.",
   "portfolio.search.label": "Projekt suchen",
   "portfolio.search.placeholder": "z. B. Einbauschrank, Badmöbel, Parkett, Terrasse München",
   "portfolio.search.chipsAria": "Häufige Suchbegriffe",
@@ -689,5 +689,15 @@
   "portfolio.legacy.p20.material": "Holz, farblos lackiert",
   "portfolio.legacy.p20.caption": "Individuelle Küche mit warmem Holzbild, funktionaler Aufteilung und wohnlichem Charakter.",
   "portfolio.legacy.p20.text": "Die Küche zeigt, dass EF-Sinn nicht nur Außenbereiche, sondern auch hochwertige Innenausbauten und Küchen umsetzt.",
-  "portfolio.legacy.p20.alt": "Farblos lackierte Holzküche in München – EF-Sinn Referenzprojekt"
+  "portfolio.legacy.p20.alt": "Farblos lackierte Holzküche in München – EF-Sinn Referenzprojekt",
+  "portfolio.categorySelect.label": "Kategorie auswählen",
+  "portfolio.categorySelect.aria": "Projektkategorie auswählen",
+  "portfolio.categorySelect.all": "Alle Projekte",
+  "portfolio.categorySelect.treppen": "Treppen",
+  "portfolio.categorySelect.terrassen": "Terrassen & Balkon",
+  "portfolio.categorySelect.moebel": "Möbel & Badmöbel",
+  "portfolio.categorySelect.kuechen": "Küchen",
+  "portfolio.categorySelect.parkett": "Parkett & Böden",
+  "portfolio.categorySelect.innenausbau": "Innenausbau & Wandverkleidung",
+  "portfolio.categorySelect.aussenbau": "Außenbau & Gartenhaus"
 }

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -538,8 +538,8 @@
   "nav.callAria": "ef-sinn telefonisch kontaktieren",
   "mobile.quickContact": "Schnellkontakt mobil",
   "portfolio.search.kicker": "Referenzsuche",
-  "portfolio.search.title": "Welches Projekt suchen Sie?",
-  "portfolio.search.text": "Suchen Sie nach Möbelbau, Einbauschrank, Badmöbel, Parkett, Terrasse, Treppe oder München. Die Projektkarten zeigen passende Beispiele und führen direkt zur Anfrage.",
+  "portfolio.search.title": "Welche Kategorie suchen Sie?",
+  "portfolio.search.text": "Wählen Sie eine feste Kategorie. Die Seite zeigt dann alle passenden Referenzen — ohne freie Texteingabe und ohne doppelte Kategorie-Buttons.",
   "portfolio.search.label": "Projekt suchen",
   "portfolio.search.placeholder": "z. B. Einbauschrank, Badmöbel, Parkett, Terrasse München",
   "portfolio.search.chipsAria": "Häufige Suchbegriffe",
@@ -689,5 +689,15 @@
   "portfolio.legacy.p20.material": "Holz, farblos lackiert",
   "portfolio.legacy.p20.caption": "Individuelle Küche mit warmem Holzbild, funktionaler Aufteilung und wohnlichem Charakter.",
   "portfolio.legacy.p20.text": "Die Küche zeigt, dass EF-Sinn nicht nur Außenbereiche, sondern auch hochwertige Innenausbauten und Küchen umsetzt.",
-  "portfolio.legacy.p20.alt": "Farblos lackierte Holzküche in München – EF-Sinn Referenzprojekt"
+  "portfolio.legacy.p20.alt": "Farblos lackierte Holzküche in München – EF-Sinn Referenzprojekt",
+  "portfolio.categorySelect.label": "Kategorie auswählen",
+  "portfolio.categorySelect.aria": "Projektkategorie auswählen",
+  "portfolio.categorySelect.all": "Alle Projekte",
+  "portfolio.categorySelect.treppen": "Treppen",
+  "portfolio.categorySelect.terrassen": "Terrassen & Balkon",
+  "portfolio.categorySelect.moebel": "Möbel & Badmöbel",
+  "portfolio.categorySelect.kuechen": "Küchen",
+  "portfolio.categorySelect.parkett": "Parkett & Böden",
+  "portfolio.categorySelect.innenausbau": "Innenausbau & Wandverkleidung",
+  "portfolio.categorySelect.aussenbau": "Außenbau & Gartenhaus"
 }

--- a/i18n/el.json
+++ b/i18n/el.json
@@ -538,8 +538,8 @@
   "nav.callAria": "Τηλεφωνική επικοινωνία με το ef-sinn",
   "mobile.quickContact": "Γρήγορη επικοινωνία για κινητά",
   "portfolio.search.kicker": "Αναζήτηση έργων",
-  "portfolio.search.title": "Τι έργο ψάχνετε;",
-  "portfolio.search.text": "Αναζητήστε έπιπλα κατά παραγγελία, εντοιχισμένες ντουλάπες, έπιπλα μπάνιου, παρκέ, βεράντες, σκάλες ή Μόναχο. Οι κάρτες έργων δείχνουν κατάλληλα παραδείγματα και οδηγούν απευθείας στην αίτηση.",
+  "portfolio.search.title": "Ποια κατηγορία ψάχνετε;",
+  "portfolio.search.text": "Επιλέξτε μια σταθερή κατηγορία. Η σελίδα εμφανίζει όλες τις σχετικές αναφορές — χωρίς ελεύθερη πληκτρολόγηση και χωρίς διπλά κουμπιά κατηγορίας.",
   "portfolio.search.label": "Αναζήτηση έργου",
   "portfolio.search.placeholder": "π.χ. εντοιχισμένη ντουλάπα, έπιπλο μπάνιου, παρκέ, βεράντα Μόναχο",
   "portfolio.search.chipsAria": "Συχνές λέξεις αναζήτησης",
@@ -689,5 +689,15 @@
   "portfolio.legacy.p20.material": "ξύλο με άχρωμο βερνίκι",
   "portfolio.legacy.p20.caption": "Ολοκληρωμένη αναφορά στο Μόναχο. Το έργο δείχνει ακριβή ξυλουργική εργασία, αρμονική ξύλινη εμφάνιση και πρακτική λύση για καθημερινή χρήση.",
   "portfolio.legacy.p20.text": "Υλικό: ξύλο με άχρωμο βερνίκι. Η έμφαση είναι στις καθαρές ενώσεις, στις ήρεμες γραμμές και στην ανθεκτική εκτέλεση. Οι ακριβείς τεχνικές λεπτομέρειες μπορούν να οριστικοποιηθούν με τον Marios πριν από τη δημοσίευση.",
-  "portfolio.legacy.p20.alt": "Ξύλινη κουζίνα με άχρωμο βερνίκι – Μόναχο – έργο αναφοράς EF-Sinn"
+  "portfolio.legacy.p20.alt": "Ξύλινη κουζίνα με άχρωμο βερνίκι – Μόναχο – έργο αναφοράς EF-Sinn",
+  "portfolio.categorySelect.label": "Επιλογή κατηγορίας",
+  "portfolio.categorySelect.aria": "Επιλογή κατηγορίας έργου",
+  "portfolio.categorySelect.all": "Όλα τα έργα",
+  "portfolio.categorySelect.treppen": "Σκάλες",
+  "portfolio.categorySelect.terrassen": "Βεράντες και μπαλκόνια",
+  "portfolio.categorySelect.moebel": "Έπιπλα και έπιπλα μπάνιου",
+  "portfolio.categorySelect.kuechen": "Κουζίνες",
+  "portfolio.categorySelect.parkett": "Παρκέ και δάπεδα",
+  "portfolio.categorySelect.innenausbau": "Εσωτερικές εργασίες και επενδύσεις τοίχων",
+  "portfolio.categorySelect.aussenbau": "Εξωτερικές εργασίες και σπιτάκια κήπου"
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -538,8 +538,8 @@
   "nav.callAria": "Call ef-sinn by phone",
   "mobile.quickContact": "Mobile quick contact",
   "portfolio.search.kicker": "Reference search",
-  "portfolio.search.title": "Which project are you looking for?",
-  "portfolio.search.text": "Search for furniture making, built-in wardrobes, bathroom furniture, parquet, terraces, stairs or Munich. The project cards show matching examples and lead directly to an inquiry.",
+  "portfolio.search.title": "Which category are you looking for?",
+  "portfolio.search.text": "Choose a fixed category. The page then shows all matching references — without free text input and without duplicate category buttons.",
   "portfolio.search.label": "Search project",
   "portfolio.search.placeholder": "e.g. built-in wardrobe, bathroom furniture, parquet, terrace Munich",
   "portfolio.search.chipsAria": "Common search terms",
@@ -689,5 +689,15 @@
   "portfolio.legacy.p20.material": "wood, clear-lacquered",
   "portfolio.legacy.p20.caption": "Completed reference in Munich. The project shows precise carpentry, a harmonious wood appearance and a practical solution for everyday use.",
   "portfolio.legacy.p20.text": "Material: wood, clear-lacquered. The focus is on clean joints, calm lines and durable execution. Exact construction details can be refined with Marios before final publication.",
-  "portfolio.legacy.p20.alt": "Clear-lacquered wooden kitchen – Munich – EF-Sinn reference project"
+  "portfolio.legacy.p20.alt": "Clear-lacquered wooden kitchen – Munich – EF-Sinn reference project",
+  "portfolio.categorySelect.label": "Select category",
+  "portfolio.categorySelect.aria": "Select project category",
+  "portfolio.categorySelect.all": "All projects",
+  "portfolio.categorySelect.treppen": "Stairs",
+  "portfolio.categorySelect.terrassen": "Terraces & balconies",
+  "portfolio.categorySelect.moebel": "Furniture & bathroom furniture",
+  "portfolio.categorySelect.kuechen": "Kitchens",
+  "portfolio.categorySelect.parkett": "Parquet & flooring",
+  "portfolio.categorySelect.innenausbau": "Interior work & wall cladding",
+  "portfolio.categorySelect.aussenbau": "Outdoor work & garden houses"
 }

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -538,8 +538,8 @@
   "nav.callAria": "Llamar a ef-sinn por teléfono",
   "mobile.quickContact": "Contacto rápido móvil",
   "portfolio.search.kicker": "Búsqueda de referencias",
-  "portfolio.search.title": "¿Qué proyecto busca?",
-  "portfolio.search.text": "Busque muebles a medida, armarios empotrados, muebles de baño, parquet, terrazas, escaleras o Múnich. Las tarjetas de proyectos muestran ejemplos adecuados y llevan directamente a la consulta.",
+  "portfolio.search.title": "¿Qué categoría busca?",
+  "portfolio.search.text": "Elija una categoría fija. La página muestra entonces todas las referencias adecuadas — sin entrada de texto libre y sin botones de categoría duplicados.",
   "portfolio.search.label": "Buscar proyecto",
   "portfolio.search.placeholder": "p. ej. armario empotrado, mueble de baño, parquet, terraza Múnich",
   "portfolio.search.chipsAria": "Términos de búsqueda frecuentes",
@@ -689,5 +689,15 @@
   "portfolio.legacy.p20.material": "madera con barniz transparente",
   "portfolio.legacy.p20.caption": "Referencia realizada en Múnich. El proyecto muestra carpintería precisa, una apariencia de madera armoniosa y una solución práctica para el uso diario.",
   "portfolio.legacy.p20.text": "Material: madera con barniz transparente. El enfoque está en uniones limpias, líneas tranquilas y una ejecución duradera. Los detalles constructivos exactos pueden ajustarse con Marios antes de la publicación final.",
-  "portfolio.legacy.p20.alt": "Cocina de madera con barniz transparente – Múnich – proyecto de referencia de EF-Sinn"
+  "portfolio.legacy.p20.alt": "Cocina de madera con barniz transparente – Múnich – proyecto de referencia de EF-Sinn",
+  "portfolio.categorySelect.label": "Seleccionar categoría",
+  "portfolio.categorySelect.aria": "Seleccionar categoría de proyecto",
+  "portfolio.categorySelect.all": "Todos los proyectos",
+  "portfolio.categorySelect.treppen": "Escaleras",
+  "portfolio.categorySelect.terrassen": "Terrazas y balcones",
+  "portfolio.categorySelect.moebel": "Muebles y muebles de baño",
+  "portfolio.categorySelect.kuechen": "Cocinas",
+  "portfolio.categorySelect.parkett": "Parquet y suelos",
+  "portfolio.categorySelect.innenausbau": "Interiorismo y revestimientos de pared",
+  "portfolio.categorySelect.aussenbau": "Exteriores y casetas de jardín"
 }

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -538,8 +538,8 @@
   "nav.callAria": "Appeler ef-sinn par téléphone",
   "mobile.quickContact": "Contact rapide mobile",
   "portfolio.search.kicker": "Recherche de références",
-  "portfolio.search.title": "Quel projet recherchez-vous ?",
-  "portfolio.search.text": "Recherchez meubles sur mesure, placard intégré, meuble de salle de bains, parquet, terrasse, escalier ou Munich. Les cartes de projets montrent des exemples adaptés et mènent directement à la demande.",
+  "portfolio.search.title": "Quelle catégorie recherchez-vous ?",
+  "portfolio.search.text": "Choisissez une catégorie fixe. La page affiche ensuite toutes les références correspondantes — sans saisie libre et sans boutons de catégorie en double.",
   "portfolio.search.label": "Rechercher un projet",
   "portfolio.search.placeholder": "p. ex. placard intégré, meuble de salle de bains, parquet, terrasse Munich",
   "portfolio.search.chipsAria": "Termes de recherche fréquents",
@@ -689,5 +689,15 @@
   "portfolio.legacy.p20.material": "bois verni incolore",
   "portfolio.legacy.p20.caption": "Référence réalisée à Munich. Le projet montre une menuiserie précise, un aspect bois harmonieux et une solution pratique au quotidien.",
   "portfolio.legacy.p20.text": "Matériau : bois verni incolore. L’accent est mis sur des raccords propres, des lignes calmes et une exécution durable. Les détails techniques exacts pourront être précisés avec Marios avant la publication finale.",
-  "portfolio.legacy.p20.alt": "Cuisine en bois vernie incolore – Munich – projet de référence EF-Sinn"
+  "portfolio.legacy.p20.alt": "Cuisine en bois vernie incolore – Munich – projet de référence EF-Sinn",
+  "portfolio.categorySelect.label": "Choisir une catégorie",
+  "portfolio.categorySelect.aria": "Choisir une catégorie de projet",
+  "portfolio.categorySelect.all": "Tous les projets",
+  "portfolio.categorySelect.treppen": "Escaliers",
+  "portfolio.categorySelect.terrassen": "Terrasses et balcons",
+  "portfolio.categorySelect.moebel": "Meubles et meubles de salle de bains",
+  "portfolio.categorySelect.kuechen": "Cuisines",
+  "portfolio.categorySelect.parkett": "Parquet et sols",
+  "portfolio.categorySelect.innenausbau": "Aménagement intérieur et bardage mural",
+  "portfolio.categorySelect.aussenbau": "Extérieur et abris de jardin"
 }

--- a/i18n/it.json
+++ b/i18n/it.json
@@ -538,8 +538,8 @@
   "nav.callAria": "Chiamare ef-sinn al telefono",
   "mobile.quickContact": "Contatto rapido mobile",
   "portfolio.search.kicker": "Ricerca referenze",
-  "portfolio.search.title": "Che progetto sta cercando?",
-  "portfolio.search.text": "Cerchi falegnameria su misura, armadi a muro, mobili bagno, parquet, terrazze, scale o Monaco. Le schede progetto mostrano esempi adatti e portano direttamente alla richiesta.",
+  "portfolio.search.title": "Quale categoria sta cercando?",
+  "portfolio.search.text": "Scelga una categoria fissa. La pagina mostra poi tutte le referenze corrispondenti — senza inserimento libero di testo e senza pulsanti categoria doppi.",
   "portfolio.search.label": "Cerca progetto",
   "portfolio.search.placeholder": "ad es. armadio a muro, mobile bagno, parquet, terrazza Monaco",
   "portfolio.search.chipsAria": "Termini di ricerca frequenti",
@@ -689,5 +689,15 @@
   "portfolio.legacy.p20.material": "legno verniciato trasparente",
   "portfolio.legacy.p20.caption": "Referenza realizzata a Monaco. Il progetto mostra lavorazione precisa, aspetto armonioso del legno e una soluzione pratica per l’uso quotidiano.",
   "portfolio.legacy.p20.text": "Materiale: legno verniciato trasparente. Il focus è su giunti puliti, linee tranquille ed esecuzione durevole. I dettagli costruttivi esatti potranno essere affinati con Marios prima della pubblicazione finale.",
-  "portfolio.legacy.p20.alt": "Cucina in legno con verniciatura trasparente – Monaco – progetto di riferimento EF-Sinn"
+  "portfolio.legacy.p20.alt": "Cucina in legno con verniciatura trasparente – Monaco – progetto di riferimento EF-Sinn",
+  "portfolio.categorySelect.label": "Seleziona categoria",
+  "portfolio.categorySelect.aria": "Seleziona categoria progetto",
+  "portfolio.categorySelect.all": "Tutti i progetti",
+  "portfolio.categorySelect.treppen": "Scale",
+  "portfolio.categorySelect.terrassen": "Terrazze e balconi",
+  "portfolio.categorySelect.moebel": "Mobili e mobili bagno",
+  "portfolio.categorySelect.kuechen": "Cucine",
+  "portfolio.categorySelect.parkett": "Parquet e pavimenti",
+  "portfolio.categorySelect.innenausbau": "Interni e rivestimenti parete",
+  "portfolio.categorySelect.aussenbau": "Esterni e casette da giardino"
 }

--- a/portfolio.html
+++ b/portfolio.html
@@ -20,7 +20,7 @@
     <meta property="og:locale" content="de_DE">
     <meta property="og:site_name" content="ef-sinn">
     <title>Portfolio & Referenzen – ef-sinn Schreiner Werkstatt München</title>
-    <link rel="stylesheet" href="styles.css?v=20260605">
+    <link rel="stylesheet" href="styles.css?v=20260609">
     <style>
         /* ===== PORTFOLIO PAGE SPECIFIC STYLES ===== */
 
@@ -847,32 +847,26 @@
             <div class="portfolio-search-panel">
                 <div>
                     <p class="section-kicker" data-i18n="portfolio.search.kicker">Referenzsuche</p>
-                    <h2 id="portfolio-search-title" data-i18n="portfolio.search.title">Welches Projekt suchen Sie?</h2>
-                    <p data-i18n="portfolio.search.text">Suchen Sie nach Möbelbau, Einbauschrank, Badmöbel, Parkett, Terrasse, Treppe oder München. Die Projektkarten zeigen passende Beispiele und führen direkt zur Anfrage.</p>
+                    <h2 id="portfolio-search-title" data-i18n="portfolio.search.title">Welche Kategorie suchen Sie?</h2>
+                    <p data-i18n="portfolio.search.text">Wählen Sie eine feste Kategorie. Die Seite zeigt dann alle passenden Referenzen — ohne freie Texteingabe und ohne doppelte Kategorie-Buttons.</p>
                 </div>
-                <label class="portfolio-search-label" for="portfolio-search" data-i18n="portfolio.search.label">Projekt suchen</label>
-                <input id="portfolio-search" class="portfolio-search-input" type="search" placeholder="z. B. Einbauschrank, Badmöbel, Parkett, Terrasse München" data-i18n-placeholder="portfolio.search.placeholder" autocomplete="off">
-                <div class="portfolio-search-chips" aria-label="Häufige Suchbegriffe" data-i18n-aria-label="portfolio.search.chipsAria">
-                    <button type="button" data-search-term="Einbauschrank" data-i18n="portfolio.search.chip.cabinet">Einbauschrank</button>
-                    <button type="button" data-search-term="Badmöbel" data-i18n="portfolio.search.chip.bath">Badmöbel</button>
-                    <button type="button" data-search-term="Parkett" data-i18n="portfolio.search.chip.parquet">Parkett</button>
-                    <button type="button" data-search-term="Terrasse" data-i18n="portfolio.search.chip.terrace">Terrasse</button>
-                    <button type="button" data-search-term="Treppe" data-i18n="portfolio.search.chip.stairs">Treppe</button>
-                    <button type="button" data-search-term="München" data-i18n="portfolio.search.chip.munich">München</button>
-                </div>
+                <label class="portfolio-search-label" for="portfolio-category-select" data-i18n="portfolio.categorySelect.label">Kategorie auswählen</label>
+                <select id="portfolio-category-select" class="portfolio-search-input" aria-label="Projektkategorie auswählen" data-i18n-aria-label="portfolio.categorySelect.aria">
+                    <option value="all" data-i18n="portfolio.categorySelect.all">Alle Projekte</option>
+                    <option value="treppen" data-i18n="portfolio.categorySelect.treppen">Treppen</option>
+                    <option value="terrassen" data-i18n="portfolio.categorySelect.terrassen">Terrassen & Balkon</option>
+                    <option value="moebel" data-i18n="portfolio.categorySelect.moebel">Möbel & Badmöbel</option>
+                    <option value="kuechen" data-i18n="portfolio.categorySelect.kuechen">Küchen</option>
+                    <option value="parkett" data-i18n="portfolio.categorySelect.parkett">Parkett & Böden</option>
+                    <option value="innenausbau" data-i18n="portfolio.categorySelect.innenausbau">Innenausbau & Wandverkleidung</option>
+                    <option value="aussenbau" data-i18n="portfolio.categorySelect.aussenbau">Außenbau & Gartenhaus</option>
+                </select>
             </div>
         </div>
     </section>
 
-    <!-- Filter -->
+    <!-- Project Count -->
     <div class="container">
-        <div class="portfolio-page-filters">
-            <button class="portfolio-page-filter active" data-filter="all" data-i18n="home.portfolio.filter.all">Alle</button>
-            <button class="portfolio-page-filter" data-filter="treppen" data-i18n="home.portfolio.filter.treppen">Treppen</button>
-            <button class="portfolio-page-filter" data-filter="terrassen" data-i18n="home.portfolio.filter.terrassen">Terrassen</button>
-            <button class="portfolio-page-filter" data-filter="moebel" data-i18n="home.portfolio.filter.moebel">Möbel</button>
-            <button class="portfolio-page-filter" data-filter="innenausbau" data-i18n="home.portfolio.filter.innenausbau">Innenausbau</button>
-        </div>
         <div class="project-count"><span id="visible-count">30</span> <span data-i18n="portfolio.projects.count">Projekte</span></div>
     </div>
 
@@ -881,7 +875,7 @@
         <div class="container">
 
             <!-- Project 1: Holztreppe I -->
-            <article class="project-card" data-category="treppen">
+            <article class="project-card" data-category="treppen" data-categories="treppen">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.label.reference">Referenzprojekt</div>
@@ -937,7 +931,7 @@
             </article>
 
             <!-- Project 2: Holztreppe II -->
-            <article class="project-card" data-category="treppen">
+            <article class="project-card" data-category="treppen" data-categories="treppen">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.label.reference">Referenzprojekt</div>
@@ -993,7 +987,7 @@
             </article>
 
             <!-- Project 3: Holzterrasse I -->
-            <article class="project-card" data-category="terrassen">
+            <article class="project-card" data-category="terrassen" data-categories="terrassen aussenbau">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.label.reference">Referenzprojekt</div>
@@ -1049,7 +1043,7 @@
             </article>
 
             <!-- Project 4: Holzterrasse II -->
-            <article class="project-card" data-category="terrassen">
+            <article class="project-card" data-category="terrassen" data-categories="terrassen aussenbau">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.label.reference">Referenzprojekt</div>
@@ -1105,7 +1099,7 @@
             </article>
 
             <!-- Project 5: Massivholztisch -->
-            <article class="project-card" data-category="moebel">
+            <article class="project-card" data-category="moebel" data-categories="moebel">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.label.reference">Referenzprojekt</div>
@@ -1161,7 +1155,7 @@
             </article>
 
             <!-- Project 6: Badmöbel -->
-            <article class="project-card" data-category="moebel">
+            <article class="project-card" data-category="moebel" data-categories="moebel innenausbau">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.label.reference">Referenzprojekt</div>
@@ -1217,7 +1211,7 @@
             </article>
 
             <!-- Project 7: Akustik-Designpaneel -->
-            <article class="project-card" data-category="innenausbau">
+            <article class="project-card" data-category="innenausbau" data-categories="innenausbau">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.label.reference">Referenzprojekt</div>
@@ -1273,7 +1267,7 @@
             </article>
 
             <!-- Project 8: Nischenregal -->
-            <article class="project-card" data-category="innenausbau">
+            <article class="project-card" data-category="innenausbau" data-categories="innenausbau moebel">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.label.reference">Referenzprojekt</div>
@@ -1333,7 +1327,7 @@
             </article>
 
             <!-- Project 9: Garderobe mit Sitzbank -->
-            <article class="project-card" data-category="innenausbau">
+            <article class="project-card" data-category="innenausbau" data-categories="innenausbau moebel">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.label.reference">Referenzprojekt</div>
@@ -1398,7 +1392,7 @@
 
 
             <!-- Project 10: Parkettboden -->
-            <article class="project-card" data-category="innenausbau">
+            <article class="project-card" data-category="innenausbau" data-categories="parkett innenausbau">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.label.reference">Referenzprojekt</div>
@@ -1467,7 +1461,7 @@
                 <h2 class="legacy-reference-title" data-i18n="portfolio.legacy.title">20 echte Referenzen aus Holzbau Karampas</h2>
                 <p data-i18n="portfolio.legacy.text">Diese Auswahl zeigt ausgeführte Terrassen-, Balkon-, Wandverkleidungs-, Gartenhaus- und Küchenprojekte. Die Bilder wurden nur dezent für ein einheitliches Webseitenbild vorbereitet.</p>
             </div>
-            <article class="project-card legacy-reference-card" data-category="terrassen">
+            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen aussenbau">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.legacy.label">Ausgeführte Referenz</div>
@@ -1503,7 +1497,7 @@
                 </div>
             </article>
 
-            <article class="project-card legacy-reference-card" data-category="terrassen">
+            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen aussenbau">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.legacy.label">Ausgeführte Referenz</div>
@@ -1539,7 +1533,7 @@
                 </div>
             </article>
 
-            <article class="project-card legacy-reference-card" data-category="terrassen">
+            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen aussenbau">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.legacy.label">Ausgeführte Referenz</div>
@@ -1575,7 +1569,7 @@
                 </div>
             </article>
 
-            <article class="project-card legacy-reference-card" data-category="terrassen">
+            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen aussenbau">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.legacy.label">Ausgeführte Referenz</div>
@@ -1611,7 +1605,7 @@
                 </div>
             </article>
 
-            <article class="project-card legacy-reference-card" data-category="terrassen">
+            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen aussenbau">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.legacy.label">Ausgeführte Referenz</div>
@@ -1647,7 +1641,7 @@
                 </div>
             </article>
 
-            <article class="project-card legacy-reference-card" data-category="terrassen">
+            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen balkon aussenbau">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.legacy.label">Ausgeführte Referenz</div>
@@ -1683,7 +1677,7 @@
                 </div>
             </article>
 
-            <article class="project-card legacy-reference-card" data-category="terrassen">
+            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen balkon aussenbau">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.legacy.label">Ausgeführte Referenz</div>
@@ -1719,7 +1713,7 @@
                 </div>
             </article>
 
-            <article class="project-card legacy-reference-card" data-category="terrassen">
+            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen balkon aussenbau">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.legacy.label">Ausgeführte Referenz</div>
@@ -1755,7 +1749,7 @@
                 </div>
             </article>
 
-            <article class="project-card legacy-reference-card" data-category="terrassen">
+            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen aussenbau">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.legacy.label">Ausgeführte Referenz</div>
@@ -1791,7 +1785,7 @@
                 </div>
             </article>
 
-            <article class="project-card legacy-reference-card" data-category="terrassen">
+            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen aussenbau">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.legacy.label">Ausgeführte Referenz</div>
@@ -1827,7 +1821,7 @@
                 </div>
             </article>
 
-            <article class="project-card legacy-reference-card" data-category="terrassen">
+            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen aussenbau">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.legacy.label">Ausgeführte Referenz</div>
@@ -1863,7 +1857,7 @@
                 </div>
             </article>
 
-            <article class="project-card legacy-reference-card" data-category="terrassen">
+            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen aussenbau">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.legacy.label">Ausgeführte Referenz</div>
@@ -1899,7 +1893,7 @@
                 </div>
             </article>
 
-            <article class="project-card legacy-reference-card" data-category="terrassen">
+            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen innenausbau aussenbau">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.legacy.label">Ausgeführte Referenz</div>
@@ -1935,7 +1929,7 @@
                 </div>
             </article>
 
-            <article class="project-card legacy-reference-card" data-category="terrassen">
+            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen innenausbau aussenbau">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.legacy.label">Ausgeführte Referenz</div>
@@ -1971,7 +1965,7 @@
                 </div>
             </article>
 
-            <article class="project-card legacy-reference-card" data-category="terrassen">
+            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen innenausbau aussenbau">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.legacy.label">Ausgeführte Referenz</div>
@@ -2007,7 +2001,7 @@
                 </div>
             </article>
 
-            <article class="project-card legacy-reference-card" data-category="terrassen">
+            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen innenausbau aussenbau">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.legacy.label">Ausgeführte Referenz</div>
@@ -2043,7 +2037,7 @@
                 </div>
             </article>
 
-            <article class="project-card legacy-reference-card" data-category="terrassen">
+            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen innenausbau aussenbau">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.legacy.label">Ausgeführte Referenz</div>
@@ -2079,7 +2073,7 @@
                 </div>
             </article>
 
-            <article class="project-card legacy-reference-card" data-category="moebel">
+            <article class="project-card legacy-reference-card" data-category="moebel" data-categories="moebel aussenbau">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.legacy.label">Ausgeführte Referenz</div>
@@ -2115,7 +2109,7 @@
                 </div>
             </article>
 
-            <article class="project-card legacy-reference-card" data-category="innenausbau">
+            <article class="project-card legacy-reference-card" data-category="innenausbau" data-categories="aussenbau">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.legacy.label">Ausgeführte Referenz</div>
@@ -2151,7 +2145,7 @@
                 </div>
             </article>
 
-            <article class="project-card legacy-reference-card" data-category="moebel">
+            <article class="project-card legacy-reference-card" data-category="moebel" data-categories="kuechen moebel innenausbau">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.legacy.label">Ausgeführte Referenz</div>
@@ -2361,31 +2355,29 @@
         </div>
     </footer>
 
-    <script src="assets/js/i18n.js?v=20260609"></script>
+    <script src="assets/js/i18n.js?v=20260609b"></script>
     <script>
     /* ===== Portfolio Page Interactions ===== */
     (function() {
         'use strict';
 
-        /* --- Category Filter + Search --- */
-        var filterBtns = document.querySelectorAll('.portfolio-page-filter');
-        var projectCards = document.querySelectorAll('.project-card[data-category]');
+        /* --- Fixed Category Select --- */
+        var categorySelect = document.getElementById('portfolio-category-select');
+        var projectCards = document.querySelectorAll('.project-card[data-category], .project-card[data-categories]');
         var countEl = document.getElementById('visible-count');
-        var searchInput = document.getElementById('portfolio-search');
-        var chipBtns = document.querySelectorAll('[data-search-term]');
         var activeFilter = 'all';
 
-        function normalize(value) {
-            return (value || '').toLowerCase().replace(/ä/g, 'ae').replace(/ö/g, 'oe').replace(/ü/g, 'ue').replace(/ß/g, 'ss');
+        function cardCategories(card) {
+            return (card.getAttribute('data-categories') || card.getAttribute('data-category') || '').split(/\s+/).filter(Boolean);
         }
 
         function applyFilters() {
-            var q = normalize(searchInput ? searchInput.value : '');
+            activeFilter = categorySelect ? categorySelect.value : 'all';
             var visible = 0;
             projectCards.forEach(function(card) {
-                var categoryMatch = activeFilter === 'all' || card.getAttribute('data-category') === activeFilter;
-                var textMatch = !q || normalize(card.textContent).indexOf(q) !== -1;
-                if (categoryMatch && textMatch) {
+                var categories = cardCategories(card);
+                var categoryMatch = activeFilter === 'all' || categories.indexOf(activeFilter) !== -1;
+                if (categoryMatch) {
                     card.removeAttribute('data-hidden');
                     visible++;
                 } else {
@@ -2395,28 +2387,9 @@
             if (countEl) countEl.textContent = visible;
         }
 
-        filterBtns.forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                filterBtns.forEach(function(b) { b.classList.remove('active'); });
-                btn.classList.add('active');
-                activeFilter = btn.getAttribute('data-filter');
-                applyFilters();
-            });
-        });
-
-        if (searchInput) {
-            searchInput.addEventListener('input', applyFilters);
+        if (categorySelect) {
+            categorySelect.addEventListener('change', applyFilters);
         }
-
-        chipBtns.forEach(function(btn) {
-            btn.addEventListener('click', function() {
-                if (searchInput) {
-                    searchInput.value = (btn.textContent || btn.getAttribute('data-search-term') || '').trim();
-                    searchInput.focus();
-                }
-                applyFilters();
-            });
-        });
 
         applyFilters();
 


### PR DESCRIPTION
## Zusammenfassung
- entfernt die doppelte Kategorie-Bedienung auf der Portfolio-Seite
- ersetzt das freie Such-/Eingabefeld durch eine feste Kategorie-Auswahl
- ordnet Projekte über Mehrfach-Kategorien zu, damit passende Referenzen in den richtigen Kategorien erscheinen
- ergänzt die neuen Auswahltexte in DE, EN, FR, EL, IT, ES und DE-AT

## Prüfung
- node -c assets/js/i18n.js
- git diff --check
- i18n-Key-Coverage für alle verwendeten data-i18n*-Keys
- lokale Firefox/WebDriver-Prüfung in allen 7 Sprachen
- keine freie Texteingabe mehr, genau eine Kategorie-Auswahl, keine doppelten Kategorie-Buttons
- Kategorie-Zählung geprüft: alle 30, Treppen 2, Terrassen/Balkon 19, Möbel/Badmöbel 6, Küchen 1, Parkett/Böden 1, Innenausbau 11, Außenbau/Gartenhaus 21