### PR TITLE
fix: use portfolio category buttons and request types

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -3,7 +3,7 @@
 <head>
     <!--
     SICHERHEITS- UND DATENSCHUTZ-ENTSCHEIDUNGEN:
-    
+
     Kontakt:
     - Anfrage-Assistent bereitet nur lokal im Browser eine mailto:-E-Mail vor
     - Kein Formular-Backend, keine automatische Speicherung, kein Tracking
@@ -26,7 +26,7 @@
     <meta name="twitter:title" content="Kontakt – ef-sinn Schreiner Werkstatt München">
     <meta name="twitter:description" content="Kostenlose Erstberatung für Maßmöbel, Parkettboden, Küchen & Innenausbau.">
     <title>Kontakt – ef-sinn | Schreiner Werkstatt München & Unterhaching</title>
-    <link rel="stylesheet" href="styles.css?v=20260605">
+    <link rel="stylesheet" href="styles.css?v=20260609c">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -89,10 +89,10 @@
                 <div class="contact-info">
                     <h2 class="section-title" data-i18n="contact.info.title">Kontaktinformationen</h2>
                     <p class="contact-intro" data-i18n="contact.info.intro">
-                        Sie haben eine Idee oder ein konkretes Projekt? 
+                        Sie haben eine Idee oder ein konkretes Projekt?
                         Kontaktieren Sie mich gerne für ein unverbindliches Beratungsgespräch.
                     </p>
-                    
+
                     <div class="info-block">
                         <h3 class="info-title" data-i18n="contact.info.office">Büro</h3>
                         <p class="info-text">
@@ -109,7 +109,7 @@
                             81245 München
                         </p>
                     </div>
-                    
+
                     <div class="info-block">
                         <h3 class="info-title" data-i18n="contact.info.phone">Telefon</h3>
                         <p class="info-text">
@@ -122,7 +122,7 @@
                             Sonntag: Geschlossen
                         </p>
                     </div>
-                    
+
                     <div class="info-block">
                         <h3 class="info-title" data-i18n="contact.info.email">E-Mail</h3>
                         <p class="info-text">
@@ -133,7 +133,7 @@
                     <div class="info-block">
                         <h3 class="info-title" data-i18n="contact.info.reach">Erreichbarkeit</h3>
                         <p class="info-text" data-i18n="contact.info.reach.text">
-                            Sie erreichen mich am besten per E-Mail oder Telefon. 
+                            Sie erreichen mich am besten per E-Mail oder Telefon.
                             Ich melde mich in der Regel innerhalb von 24 Stunden bei Ihnen zurück – bei Anrufen natürlich sofort.
                         </p>
                     </div>
@@ -167,16 +167,17 @@
                             <p class="inquiry-note small" data-i18n="contact.inquiry.type.help">Wählen Sie eine Vorlage oder schreiben Sie unten Ihre eigene Projektart.</p>
                             <input id="inq-type-value" type="hidden" name="type" value="Maßmöbel / Einbauschrank" data-i18n-value="contact.inquiry.type.customFurniture">
                             <div class="project-template-grid" role="group" aria-label="Projektart Vorlagen" data-i18n-aria-label="contact.inquiry.type.templatesAria">
-                                <button type="button" class="project-template-btn active" data-project-type="Maßmöbel / Einbauschrank" data-i18n="contact.inquiry.type.customFurniture" data-i18n-data-project-type="contact.inquiry.type.customFurniture">Maßmöbel / Einbauschrank</button>
-                                <button type="button" class="project-template-btn" data-project-type="Küche nach Maß" data-i18n="contact.inquiry.type.kitchen" data-i18n-data-project-type="contact.inquiry.type.kitchen">Küche nach Maß</button>
-                                <button type="button" class="project-template-btn" data-project-type="Parkett verlegen" data-i18n="contact.inquiry.type.parquetInstall" data-i18n-data-project-type="contact.inquiry.type.parquetInstall">Parkett verlegen</button>
-                                <button type="button" class="project-template-btn" data-project-type="Parkett schleifen" data-i18n="contact.inquiry.type.parquetSand" data-i18n-data-project-type="contact.inquiry.type.parquetSand">Parkett schleifen</button>
-                                <button type="button" class="project-template-btn" data-project-type="Holzterrasse" data-i18n="contact.inquiry.type.terrace" data-i18n-data-project-type="contact.inquiry.type.terrace">Holzterrasse</button>
-                                <button type="button" class="project-template-btn" data-project-type="Holztreppe" data-i18n="contact.inquiry.type.stairs" data-i18n-data-project-type="contact.inquiry.type.stairs">Holztreppe</button>
-                                <button type="button" class="project-template-btn" data-project-type="Badmöbel nach Maß" data-i18n="contact.inquiry.type.bathroomFurniture" data-i18n-data-project-type="contact.inquiry.type.bathroomFurniture">Badmöbel nach Maß</button>
-                                <button type="button" class="project-template-btn" data-project-type="Innenausbau / Wandverkleidung" data-i18n="contact.inquiry.type.interior" data-i18n-data-project-type="contact.inquiry.type.interior">Innenausbau / Wandverkleidung</button>
-                                <button type="button" class="project-template-btn" data-project-type="Reparatur / Restaurierung" data-i18n="contact.inquiry.type.repair" data-i18n-data-project-type="contact.inquiry.type.repair">Reparatur / Restaurierung</button>
-                                <button type="button" class="project-template-btn" data-project-type="Beratung / Aufmaß vor Ort" data-i18n="contact.inquiry.type.consultation" data-i18n-data-project-type="contact.inquiry.type.consultation">Beratung / Aufmaß vor Ort</button>
+                                <button type="button" class="project-template-btn active" data-project-key="customFurniture" data-project-type="Maßmöbel / Einbauschrank" data-i18n="contact.inquiry.type.customFurniture" data-i18n-data-project-type="contact.inquiry.type.customFurniture">Maßmöbel / Einbauschrank</button>
+                                <button type="button" class="project-template-btn" data-project-key="kitchen" data-project-type="Küche nach Maß" data-i18n="contact.inquiry.type.kitchen" data-i18n-data-project-type="contact.inquiry.type.kitchen">Küche nach Maß</button>
+                                <button type="button" class="project-template-btn" data-project-key="parquetInstall" data-project-type="Parkett verlegen" data-i18n="contact.inquiry.type.parquetInstall" data-i18n-data-project-type="contact.inquiry.type.parquetInstall">Parkett verlegen</button>
+                                <button type="button" class="project-template-btn" data-project-key="parquetSand" data-project-type="Parkett schleifen" data-i18n="contact.inquiry.type.parquetSand" data-i18n-data-project-type="contact.inquiry.type.parquetSand">Parkett schleifen</button>
+                                <button type="button" class="project-template-btn" data-project-key="terrace" data-project-type="Holzterrasse" data-i18n="contact.inquiry.type.terrace" data-i18n-data-project-type="contact.inquiry.type.terrace">Holzterrasse</button>
+                                <button type="button" class="project-template-btn" data-project-key="stairs" data-project-type="Holztreppe" data-i18n="contact.inquiry.type.stairs" data-i18n-data-project-type="contact.inquiry.type.stairs">Holztreppe</button>
+                                <button type="button" class="project-template-btn" data-project-key="bathroomFurniture" data-project-type="Badmöbel nach Maß" data-i18n="contact.inquiry.type.bathroomFurniture" data-i18n-data-project-type="contact.inquiry.type.bathroomFurniture">Badmöbel nach Maß</button>
+                                <button type="button" class="project-template-btn" data-project-key="interior" data-project-type="Innenausbau / Wandverkleidung" data-i18n="contact.inquiry.type.interior" data-i18n-data-project-type="contact.inquiry.type.interior">Innenausbau / Wandverkleidung</button>
+                                <button type="button" class="project-template-btn" data-project-key="outdoor" data-project-type="Außenbau / Gartenhaus" data-i18n="contact.inquiry.type.outdoor" data-i18n-data-project-type="contact.inquiry.type.outdoor">Außenbau / Gartenhaus</button>
+                                <button type="button" class="project-template-btn" data-project-key="repair" data-project-type="Reparatur / Restaurierung" data-i18n="contact.inquiry.type.repair" data-i18n-data-project-type="contact.inquiry.type.repair">Reparatur / Restaurierung</button>
+                                <button type="button" class="project-template-btn" data-project-key="consultation" data-project-type="Beratung / Aufmaß vor Ort" data-i18n="contact.inquiry.type.consultation" data-i18n-data-project-type="contact.inquiry.type.consultation">Beratung / Aufmaß vor Ort</button>
                             </div>
                         </fieldset>
 
@@ -247,7 +248,7 @@
                         <strong data-i18n="footer.workshop.label">Werkstatt:</strong> Germeringer Weg 3C, 81245 München
                     </p>
                 </div>
-                
+
                 <div class="footer-column">
                     <h3 class="footer-title" data-i18n="footer.nav">Navigation</h3>
                     <ul class="footer-links">
@@ -258,7 +259,7 @@
                         <li><a href="contact.html" data-i18n="nav.contact">Kontakt</a></li>
                     </ul>
                 </div>
-                
+
                 <div class="footer-column">
                     <h3 class="footer-title" data-i18n="footer.legal">Rechtliches</h3>
                     <ul class="footer-links">
@@ -267,13 +268,13 @@
                     </ul>
                 </div>
             </div>
-            
+
             <div class="footer-bottom">
                 <p><span data-i18n="footer.copyright">© 2026 ef-sinn. Alle Rechte vorbehalten.</span></p>
             </div>
         </div>
     </footer>
-    <script src="assets/js/i18n.js"></script>
+    <script src="assets/js/i18n.js?v=20260609c"></script>
 
     <script>
     (function(){
@@ -281,20 +282,53 @@
       if(!form) return;
       var templateBtns = form.querySelectorAll('.project-template-btn');
       var typeValueInput = document.getElementById('inq-type-value');
+      var projectTypeAliases = {
+        moebel: 'customFurniture', furniture: 'customFurniture', customFurniture: 'customFurniture', einbauschrank: 'customFurniture',
+        kitchen: 'kitchen', kueche: 'kitchen', kuechen: 'kitchen',
+        parquet: 'parquetInstall', parkett: 'parquetInstall', parquetInstall: 'parquetInstall', parquetSand: 'parquetSand',
+        terrace: 'terrace', terrassen: 'terrace', balkon: 'terrace', balcony: 'terrace',
+        stairs: 'stairs', treppen: 'stairs',
+        bathroomFurniture: 'bathroomFurniture', badmoebel: 'bathroomFurniture', bath: 'bathroomFurniture',
+        interior: 'interior', innenausbau: 'interior', wandverkleidung: 'interior',
+        outdoor: 'outdoor', aussenbau: 'outdoor', gardenhouse: 'outdoor', gartenhaus: 'outdoor',
+        repair: 'repair', consultation: 'consultation'
+      };
+      function normalizeProjectKey(value){
+        return projectTypeAliases[value] || value || '';
+      }
+      function selectProjectType(key){
+        key = normalizeProjectKey(key);
+        var selected = null;
+        templateBtns.forEach(function(btn){
+          var isActive = btn.getAttribute('data-project-key') === key;
+          btn.classList.toggle('active', isActive);
+          btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+          if(isActive) selected = btn;
+        });
+        if(!selected && templateBtns[0]) {
+          selected = templateBtns[0];
+          selected.classList.add('active');
+          selected.setAttribute('aria-pressed', 'true');
+        }
+        if(selected && typeValueInput) typeValueInput.value = selected.getAttribute('data-project-type') || '';
+      }
       templateBtns.forEach(function(btn){
         btn.addEventListener('click', function(){
-          templateBtns.forEach(function(b){ b.classList.remove('active'); b.removeAttribute('aria-pressed'); });
-          btn.classList.add('active');
-          btn.setAttribute('aria-pressed', 'true');
-          if(typeValueInput) typeValueInput.value = btn.getAttribute('data-project-type') || '';
+          selectProjectType(btn.getAttribute('data-project-key'));
         });
       });
-      if(templateBtns[0]) templateBtns[0].setAttribute('aria-pressed', 'true');
+      function requestedProjectType(){
+        try {
+          var params = new URLSearchParams(window.location.search || '');
+          return params.get('project') || params.get('type') || params.get('projekt') || '';
+        } catch(e) { return ''; }
+      }
       function syncSelectedProjectType(){
         var active = form.querySelector('.project-template-btn.active');
         if(active && typeValueInput) typeValueInput.value = active.getAttribute('data-project-type') || '';
       }
       document.addEventListener('efSinn:i18nApplied', syncSelectedProjectType);
+      selectProjectType(requestedProjectType() || 'customFurniture');
       syncSelectedProjectType();
 
       form.addEventListener('submit', function(e){

--- a/i18n/de-AT.json
+++ b/i18n/de-AT.json
@@ -539,7 +539,7 @@
   "mobile.quickContact": "Schnellkontakt mobil",
   "portfolio.search.kicker": "Referenzsuche",
   "portfolio.search.title": "Welche Kategorie suchen Sie?",
-  "portfolio.search.text": "Wählen Sie eine feste Kategorie. Die Seite zeigt dann alle passenden Referenzen — ohne freie Texteingabe und ohne doppelte Kategorie-Buttons.",
+  "portfolio.search.text": "Tippen Sie auf eine feste Kategorie. Die Seite zeigt alle passenden Referenzen — ohne freie Texteingabe und nur mit einer Button-Reihe.",
   "portfolio.search.label": "Projekt suchen",
   "portfolio.search.placeholder": "z. B. Einbauschrank, Badmöbel, Parkett, Terrasse München",
   "portfolio.search.chipsAria": "Häufige Suchbegriffe",
@@ -699,5 +699,7 @@
   "portfolio.categorySelect.kuechen": "Küchen",
   "portfolio.categorySelect.parkett": "Parkett & Böden",
   "portfolio.categorySelect.innenausbau": "Innenausbau & Wandverkleidung",
-  "portfolio.categorySelect.aussenbau": "Außenbau & Gartenhaus"
+  "portfolio.categorySelect.aussenbau": "Außenbau & Gartenhaus",
+  "portfolio.categoryButtons.aria": "Projektkategorien",
+  "contact.inquiry.type.outdoor": "Außenbau / Gartenhaus"
 }

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -539,7 +539,7 @@
   "mobile.quickContact": "Schnellkontakt mobil",
   "portfolio.search.kicker": "Referenzsuche",
   "portfolio.search.title": "Welche Kategorie suchen Sie?",
-  "portfolio.search.text": "Wählen Sie eine feste Kategorie. Die Seite zeigt dann alle passenden Referenzen — ohne freie Texteingabe und ohne doppelte Kategorie-Buttons.",
+  "portfolio.search.text": "Tippen Sie auf eine feste Kategorie. Die Seite zeigt alle passenden Referenzen — ohne freie Texteingabe und nur mit einer Button-Reihe.",
   "portfolio.search.label": "Projekt suchen",
   "portfolio.search.placeholder": "z. B. Einbauschrank, Badmöbel, Parkett, Terrasse München",
   "portfolio.search.chipsAria": "Häufige Suchbegriffe",
@@ -699,5 +699,7 @@
   "portfolio.categorySelect.kuechen": "Küchen",
   "portfolio.categorySelect.parkett": "Parkett & Böden",
   "portfolio.categorySelect.innenausbau": "Innenausbau & Wandverkleidung",
-  "portfolio.categorySelect.aussenbau": "Außenbau & Gartenhaus"
+  "portfolio.categorySelect.aussenbau": "Außenbau & Gartenhaus",
+  "portfolio.categoryButtons.aria": "Projektkategorien",
+  "contact.inquiry.type.outdoor": "Außenbau / Gartenhaus"
 }

--- a/i18n/el.json
+++ b/i18n/el.json
@@ -539,7 +539,7 @@
   "mobile.quickContact": "Γρήγορη επικοινωνία για κινητά",
   "portfolio.search.kicker": "Αναζήτηση έργων",
   "portfolio.search.title": "Ποια κατηγορία ψάχνετε;",
-  "portfolio.search.text": "Επιλέξτε μια σταθερή κατηγορία. Η σελίδα εμφανίζει όλες τις σχετικές αναφορές — χωρίς ελεύθερη πληκτρολόγηση και χωρίς διπλά κουμπιά κατηγορίας.",
+  "portfolio.search.text": "Πατήστε μια σταθερή κατηγορία. Η σελίδα εμφανίζει όλες τις σχετικές αναφορές — χωρίς ελεύθερη πληκτρολόγηση και μόνο με μία σειρά κουμπιών.",
   "portfolio.search.label": "Αναζήτηση έργου",
   "portfolio.search.placeholder": "π.χ. εντοιχισμένη ντουλάπα, έπιπλο μπάνιου, παρκέ, βεράντα Μόναχο",
   "portfolio.search.chipsAria": "Συχνές λέξεις αναζήτησης",
@@ -699,5 +699,7 @@
   "portfolio.categorySelect.kuechen": "Κουζίνες",
   "portfolio.categorySelect.parkett": "Παρκέ και δάπεδα",
   "portfolio.categorySelect.innenausbau": "Εσωτερικές εργασίες και επενδύσεις τοίχων",
-  "portfolio.categorySelect.aussenbau": "Εξωτερικές εργασίες και σπιτάκια κήπου"
+  "portfolio.categorySelect.aussenbau": "Εξωτερικές εργασίες και σπιτάκια κήπου",
+  "portfolio.categoryButtons.aria": "Κατηγορίες έργων",
+  "contact.inquiry.type.outdoor": "Εξωτερικές εργασίες / σπιτάκι κήπου"
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -539,7 +539,7 @@
   "mobile.quickContact": "Mobile quick contact",
   "portfolio.search.kicker": "Reference search",
   "portfolio.search.title": "Which category are you looking for?",
-  "portfolio.search.text": "Choose a fixed category. The page then shows all matching references — without free text input and without duplicate category buttons.",
+  "portfolio.search.text": "Tap a fixed category. The page shows all matching references — without free text input and with only one row of buttons.",
   "portfolio.search.label": "Search project",
   "portfolio.search.placeholder": "e.g. built-in wardrobe, bathroom furniture, parquet, terrace Munich",
   "portfolio.search.chipsAria": "Common search terms",
@@ -699,5 +699,7 @@
   "portfolio.categorySelect.kuechen": "Kitchens",
   "portfolio.categorySelect.parkett": "Parquet & flooring",
   "portfolio.categorySelect.innenausbau": "Interior work & wall cladding",
-  "portfolio.categorySelect.aussenbau": "Outdoor work & garden houses"
+  "portfolio.categorySelect.aussenbau": "Outdoor work & garden houses",
+  "portfolio.categoryButtons.aria": "Project categories",
+  "contact.inquiry.type.outdoor": "Outdoor work / garden house"
 }

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -539,7 +539,7 @@
   "mobile.quickContact": "Contacto rápido móvil",
   "portfolio.search.kicker": "Búsqueda de referencias",
   "portfolio.search.title": "¿Qué categoría busca?",
-  "portfolio.search.text": "Elija una categoría fija. La página muestra entonces todas las referencias adecuadas — sin entrada de texto libre y sin botones de categoría duplicados.",
+  "portfolio.search.text": "Toque una categoría fija. La página muestra todas las referencias adecuadas — sin entrada de texto libre y con una sola fila de botones.",
   "portfolio.search.label": "Buscar proyecto",
   "portfolio.search.placeholder": "p. ej. armario empotrado, mueble de baño, parquet, terraza Múnich",
   "portfolio.search.chipsAria": "Términos de búsqueda frecuentes",
@@ -699,5 +699,7 @@
   "portfolio.categorySelect.kuechen": "Cocinas",
   "portfolio.categorySelect.parkett": "Parquet y suelos",
   "portfolio.categorySelect.innenausbau": "Interiorismo y revestimientos de pared",
-  "portfolio.categorySelect.aussenbau": "Exteriores y casetas de jardín"
+  "portfolio.categorySelect.aussenbau": "Exteriores y casetas de jardín",
+  "portfolio.categoryButtons.aria": "Categorías de proyecto",
+  "contact.inquiry.type.outdoor": "Exteriores / caseta de jardín"
 }

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -539,7 +539,7 @@
   "mobile.quickContact": "Contact rapide mobile",
   "portfolio.search.kicker": "Recherche de références",
   "portfolio.search.title": "Quelle catégorie recherchez-vous ?",
-  "portfolio.search.text": "Choisissez une catégorie fixe. La page affiche ensuite toutes les références correspondantes — sans saisie libre et sans boutons de catégorie en double.",
+  "portfolio.search.text": "Touchez une catégorie fixe. La page affiche toutes les références correspondantes — sans saisie libre et avec une seule rangée de boutons.",
   "portfolio.search.label": "Rechercher un projet",
   "portfolio.search.placeholder": "p. ex. placard intégré, meuble de salle de bains, parquet, terrasse Munich",
   "portfolio.search.chipsAria": "Termes de recherche fréquents",
@@ -699,5 +699,7 @@
   "portfolio.categorySelect.kuechen": "Cuisines",
   "portfolio.categorySelect.parkett": "Parquet et sols",
   "portfolio.categorySelect.innenausbau": "Aménagement intérieur et bardage mural",
-  "portfolio.categorySelect.aussenbau": "Extérieur et abris de jardin"
+  "portfolio.categorySelect.aussenbau": "Extérieur et abris de jardin",
+  "portfolio.categoryButtons.aria": "Catégories de projets",
+  "contact.inquiry.type.outdoor": "Extérieur / abri de jardin"
 }

--- a/i18n/it.json
+++ b/i18n/it.json
@@ -539,7 +539,7 @@
   "mobile.quickContact": "Contatto rapido mobile",
   "portfolio.search.kicker": "Ricerca referenze",
   "portfolio.search.title": "Quale categoria sta cercando?",
-  "portfolio.search.text": "Scelga una categoria fissa. La pagina mostra poi tutte le referenze corrispondenti — senza inserimento libero di testo e senza pulsanti categoria doppi.",
+  "portfolio.search.text": "Tocchi una categoria fissa. La pagina mostra tutte le referenze corrispondenti — senza inserimento libero e con una sola fila di pulsanti.",
   "portfolio.search.label": "Cerca progetto",
   "portfolio.search.placeholder": "ad es. armadio a muro, mobile bagno, parquet, terrazza Monaco",
   "portfolio.search.chipsAria": "Termini di ricerca frequenti",
@@ -699,5 +699,7 @@
   "portfolio.categorySelect.kuechen": "Cucine",
   "portfolio.categorySelect.parkett": "Parquet e pavimenti",
   "portfolio.categorySelect.innenausbau": "Interni e rivestimenti parete",
-  "portfolio.categorySelect.aussenbau": "Esterni e casette da giardino"
+  "portfolio.categorySelect.aussenbau": "Esterni e casette da giardino",
+  "portfolio.categoryButtons.aria": "Categorie progetto",
+  "contact.inquiry.type.outdoor": "Esterni / casetta da giardino"
 }

--- a/portfolio.html
+++ b/portfolio.html
@@ -20,7 +20,7 @@
     <meta property="og:locale" content="de_DE">
     <meta property="og:site_name" content="ef-sinn">
     <title>Portfolio & Referenzen – ef-sinn Schreiner Werkstatt München</title>
-    <link rel="stylesheet" href="styles.css?v=20260609">
+    <link rel="stylesheet" href="styles.css?v=20260609c">
     <style>
         /* ===== PORTFOLIO PAGE SPECIFIC STYLES ===== */
 
@@ -848,19 +848,19 @@
                 <div>
                     <p class="section-kicker" data-i18n="portfolio.search.kicker">Referenzsuche</p>
                     <h2 id="portfolio-search-title" data-i18n="portfolio.search.title">Welche Kategorie suchen Sie?</h2>
-                    <p data-i18n="portfolio.search.text">Wählen Sie eine feste Kategorie. Die Seite zeigt dann alle passenden Referenzen — ohne freie Texteingabe und ohne doppelte Kategorie-Buttons.</p>
+                    <p data-i18n="portfolio.search.text">Tippen Sie auf eine feste Kategorie. Die Seite zeigt alle passenden Referenzen — ohne freie Texteingabe und nur mit einer Button-Reihe.</p>
                 </div>
-                <label class="portfolio-search-label" for="portfolio-category-select" data-i18n="portfolio.categorySelect.label">Kategorie auswählen</label>
-                <select id="portfolio-category-select" class="portfolio-search-input" aria-label="Projektkategorie auswählen" data-i18n-aria-label="portfolio.categorySelect.aria">
-                    <option value="all" data-i18n="portfolio.categorySelect.all">Alle Projekte</option>
-                    <option value="treppen" data-i18n="portfolio.categorySelect.treppen">Treppen</option>
-                    <option value="terrassen" data-i18n="portfolio.categorySelect.terrassen">Terrassen & Balkon</option>
-                    <option value="moebel" data-i18n="portfolio.categorySelect.moebel">Möbel & Badmöbel</option>
-                    <option value="kuechen" data-i18n="portfolio.categorySelect.kuechen">Küchen</option>
-                    <option value="parkett" data-i18n="portfolio.categorySelect.parkett">Parkett & Böden</option>
-                    <option value="innenausbau" data-i18n="portfolio.categorySelect.innenausbau">Innenausbau & Wandverkleidung</option>
-                    <option value="aussenbau" data-i18n="portfolio.categorySelect.aussenbau">Außenbau & Gartenhaus</option>
-                </select>
+                <div class="portfolio-search-label" id="portfolio-category-label" data-i18n="portfolio.categorySelect.label">Kategorie auswählen</div>
+                <div class="portfolio-category-buttons" role="group" aria-labelledby="portfolio-category-label" data-i18n-aria-label="portfolio.categoryButtons.aria">
+                    <button type="button" class="portfolio-category-btn active" data-filter="all" aria-pressed="true" data-i18n="portfolio.categorySelect.all">Alle Projekte</button>
+                    <button type="button" class="portfolio-category-btn" data-filter="treppen" aria-pressed="false" data-i18n="portfolio.categorySelect.treppen">Treppen</button>
+                    <button type="button" class="portfolio-category-btn" data-filter="terrassen" aria-pressed="false" data-i18n="portfolio.categorySelect.terrassen">Terrassen & Balkon</button>
+                    <button type="button" class="portfolio-category-btn" data-filter="moebel" aria-pressed="false" data-i18n="portfolio.categorySelect.moebel">Möbel & Badmöbel</button>
+                    <button type="button" class="portfolio-category-btn" data-filter="kuechen" aria-pressed="false" data-i18n="portfolio.categorySelect.kuechen">Küchen</button>
+                    <button type="button" class="portfolio-category-btn" data-filter="parkett" aria-pressed="false" data-i18n="portfolio.categorySelect.parkett">Parkett & Böden</button>
+                    <button type="button" class="portfolio-category-btn" data-filter="innenausbau" aria-pressed="false" data-i18n="portfolio.categorySelect.innenausbau">Innenausbau & Wandverkleidung</button>
+                    <button type="button" class="portfolio-category-btn" data-filter="aussenbau" aria-pressed="false" data-i18n="portfolio.categorySelect.aussenbau">Außenbau & Gartenhaus</button>
+                </div>
             </div>
         </div>
     </section>
@@ -875,7 +875,7 @@
         <div class="container">
 
             <!-- Project 1: Holztreppe I -->
-            <article class="project-card" data-category="treppen" data-categories="treppen">
+            <article class="project-card" data-category="treppen" data-categories="treppen" data-request-type="stairs">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.label.reference">Referenzprojekt</div>
@@ -925,13 +925,13 @@
                 </div>
 
                 <div class="project-request">
-                    <a class="btn btn-secondary btn-small" href="contact.html#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
+                    <a class="btn btn-secondary btn-small" href="contact.html?project=stairs#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
                     <span data-i18n="portfolio.request.note">Kurze Beschreibung genügt – wir melden uns persönlich.</span>
                 </div>
             </article>
 
             <!-- Project 2: Holztreppe II -->
-            <article class="project-card" data-category="treppen" data-categories="treppen">
+            <article class="project-card" data-category="treppen" data-categories="treppen" data-request-type="stairs">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.label.reference">Referenzprojekt</div>
@@ -981,13 +981,13 @@
                 </div>
 
                 <div class="project-request">
-                    <a class="btn btn-secondary btn-small" href="contact.html#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
+                    <a class="btn btn-secondary btn-small" href="contact.html?project=stairs#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
                     <span data-i18n="portfolio.request.note">Kurze Beschreibung genügt – wir melden uns persönlich.</span>
                 </div>
             </article>
 
             <!-- Project 3: Holzterrasse I -->
-            <article class="project-card" data-category="terrassen" data-categories="terrassen aussenbau">
+            <article class="project-card" data-category="terrassen" data-categories="terrassen aussenbau" data-request-type="terrace">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.label.reference">Referenzprojekt</div>
@@ -1037,13 +1037,13 @@
                 </div>
 
                 <div class="project-request">
-                    <a class="btn btn-secondary btn-small" href="contact.html#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
+                    <a class="btn btn-secondary btn-small" href="contact.html?project=terrace#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
                     <span data-i18n="portfolio.request.note">Kurze Beschreibung genügt – wir melden uns persönlich.</span>
                 </div>
             </article>
 
             <!-- Project 4: Holzterrasse II -->
-            <article class="project-card" data-category="terrassen" data-categories="terrassen aussenbau">
+            <article class="project-card" data-category="terrassen" data-categories="terrassen aussenbau" data-request-type="terrace">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.label.reference">Referenzprojekt</div>
@@ -1093,13 +1093,13 @@
                 </div>
 
                 <div class="project-request">
-                    <a class="btn btn-secondary btn-small" href="contact.html#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
+                    <a class="btn btn-secondary btn-small" href="contact.html?project=terrace#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
                     <span data-i18n="portfolio.request.note">Kurze Beschreibung genügt – wir melden uns persönlich.</span>
                 </div>
             </article>
 
             <!-- Project 5: Massivholztisch -->
-            <article class="project-card" data-category="moebel" data-categories="moebel">
+            <article class="project-card" data-category="moebel" data-categories="moebel" data-request-type="customFurniture">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.label.reference">Referenzprojekt</div>
@@ -1149,13 +1149,13 @@
                 </div>
 
                 <div class="project-request">
-                    <a class="btn btn-secondary btn-small" href="contact.html#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
+                    <a class="btn btn-secondary btn-small" href="contact.html?project=customFurniture#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
                     <span data-i18n="portfolio.request.note">Kurze Beschreibung genügt – wir melden uns persönlich.</span>
                 </div>
             </article>
 
             <!-- Project 6: Badmöbel -->
-            <article class="project-card" data-category="moebel" data-categories="moebel innenausbau">
+            <article class="project-card" data-category="moebel" data-categories="moebel innenausbau" data-request-type="bathroomFurniture">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.label.reference">Referenzprojekt</div>
@@ -1205,13 +1205,13 @@
                 </div>
 
                 <div class="project-request">
-                    <a class="btn btn-secondary btn-small" href="contact.html#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
+                    <a class="btn btn-secondary btn-small" href="contact.html?project=bathroomFurniture#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
                     <span data-i18n="portfolio.request.note">Kurze Beschreibung genügt – wir melden uns persönlich.</span>
                 </div>
             </article>
 
             <!-- Project 7: Akustik-Designpaneel -->
-            <article class="project-card" data-category="innenausbau" data-categories="innenausbau">
+            <article class="project-card" data-category="innenausbau" data-categories="innenausbau" data-request-type="interior">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.label.reference">Referenzprojekt</div>
@@ -1261,13 +1261,13 @@
                 </div>
 
                 <div class="project-request">
-                    <a class="btn btn-secondary btn-small" href="contact.html#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
+                    <a class="btn btn-secondary btn-small" href="contact.html?project=interior#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
                     <span data-i18n="portfolio.request.note">Kurze Beschreibung genügt – wir melden uns persönlich.</span>
                 </div>
             </article>
 
             <!-- Project 8: Nischenregal -->
-            <article class="project-card" data-category="innenausbau" data-categories="innenausbau moebel">
+            <article class="project-card" data-category="innenausbau" data-categories="innenausbau moebel" data-request-type="customFurniture">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.label.reference">Referenzprojekt</div>
@@ -1321,13 +1321,13 @@
                 </div>
 
                 <div class="project-request">
-                    <a class="btn btn-secondary btn-small" href="contact.html#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
+                    <a class="btn btn-secondary btn-small" href="contact.html?project=customFurniture#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
                     <span data-i18n="portfolio.request.note">Kurze Beschreibung genügt – wir melden uns persönlich.</span>
                 </div>
             </article>
 
             <!-- Project 9: Garderobe mit Sitzbank -->
-            <article class="project-card" data-category="innenausbau" data-categories="innenausbau moebel">
+            <article class="project-card" data-category="innenausbau" data-categories="innenausbau moebel" data-request-type="customFurniture">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.label.reference">Referenzprojekt</div>
@@ -1385,14 +1385,14 @@
                 </div>
 
                 <div class="project-request">
-                    <a class="btn btn-secondary btn-small" href="contact.html#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
+                    <a class="btn btn-secondary btn-small" href="contact.html?project=customFurniture#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
                     <span data-i18n="portfolio.request.note">Kurze Beschreibung genügt – wir melden uns persönlich.</span>
                 </div>
             </article>
 
 
             <!-- Project 10: Parkettboden -->
-            <article class="project-card" data-category="innenausbau" data-categories="parkett innenausbau">
+            <article class="project-card" data-category="innenausbau" data-categories="parkett innenausbau" data-request-type="parquetInstall">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.label.reference">Referenzprojekt</div>
@@ -1449,7 +1449,7 @@
                     </div>
                 </div>
                 <div class="project-request">
-                    <a class="btn btn-secondary btn-small" href="contact.html#anfrage-assistent" data-i18n="portfolio.p10.request">Parkett-Projekt anfragen</a>
+                    <a class="btn btn-secondary btn-small" href="contact.html?project=parquetInstall#anfrage-assistent" data-i18n="portfolio.p10.request">Parkett-Projekt anfragen</a>
                     <span data-i18n="portfolio.p10.requestNote">Fotos vom Boden helfen bei der ersten Einschätzung.</span>
                 </div>
             </article>
@@ -1461,7 +1461,7 @@
                 <h2 class="legacy-reference-title" data-i18n="portfolio.legacy.title">20 echte Referenzen aus Holzbau Karampas</h2>
                 <p data-i18n="portfolio.legacy.text">Diese Auswahl zeigt ausgeführte Terrassen-, Balkon-, Wandverkleidungs-, Gartenhaus- und Küchenprojekte. Die Bilder wurden nur dezent für ein einheitliches Webseitenbild vorbereitet.</p>
             </div>
-            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen aussenbau">
+            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen aussenbau" data-request-type="terrace">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.legacy.label">Ausgeführte Referenz</div>
@@ -1492,12 +1492,12 @@
                     <p class="desc-text" data-i18n="portfolio.legacy.p01.text">Die Stufenanlage wurde so ausgeführt, dass sie nicht nur als Zugang, sondern auch als Sitzfläche und Gestaltungselement funktioniert.</p>
                 </div>
                 <div class="project-request">
-                    <a class="btn btn-secondary btn-small" href="contact.html#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
+                    <a class="btn btn-secondary btn-small" href="contact.html?project=terrace#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
                     <span data-i18n="portfolio.request.note">Kurze Beschreibung genügt – wir melden uns persönlich.</span>
                 </div>
             </article>
 
-            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen aussenbau">
+            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen aussenbau" data-request-type="terrace">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.legacy.label">Ausgeführte Referenz</div>
@@ -1528,12 +1528,12 @@
                     <p class="desc-text" data-i18n="portfolio.legacy.p02.text">Die klare Kantenführung zeigt die handwerkliche Genauigkeit bei sichtbaren Anschlussdetails.</p>
                 </div>
                 <div class="project-request">
-                    <a class="btn btn-secondary btn-small" href="contact.html#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
+                    <a class="btn btn-secondary btn-small" href="contact.html?project=terrace#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
                     <span data-i18n="portfolio.request.note">Kurze Beschreibung genügt – wir melden uns persönlich.</span>
                 </div>
             </article>
 
-            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen aussenbau">
+            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen aussenbau" data-request-type="terrace">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.legacy.label">Ausgeführte Referenz</div>
@@ -1564,12 +1564,12 @@
                     <p class="desc-text" data-i18n="portfolio.legacy.p03.text">Die reduzierte Gestaltung lässt die Holzfläche ruhig wirken und stärkt die Architektur des Hauses.</p>
                 </div>
                 <div class="project-request">
-                    <a class="btn btn-secondary btn-small" href="contact.html#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
+                    <a class="btn btn-secondary btn-small" href="contact.html?project=terrace#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
                     <span data-i18n="portfolio.request.note">Kurze Beschreibung genügt – wir melden uns persönlich.</span>
                 </div>
             </article>
 
-            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen aussenbau">
+            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen aussenbau" data-request-type="terrace">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.legacy.label">Ausgeführte Referenz</div>
@@ -1600,12 +1600,12 @@
                     <p class="desc-text" data-i18n="portfolio.legacy.p04.text">Die Fläche wurde als langlebige und pflegefähige Outdoor-Zone für den Alltag gestaltet.</p>
                 </div>
                 <div class="project-request">
-                    <a class="btn btn-secondary btn-small" href="contact.html#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
+                    <a class="btn btn-secondary btn-small" href="contact.html?project=terrace#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
                     <span data-i18n="portfolio.request.note">Kurze Beschreibung genügt – wir melden uns persönlich.</span>
                 </div>
             </article>
 
-            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen aussenbau">
+            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen aussenbau" data-request-type="terrace">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.legacy.label">Ausgeführte Referenz</div>
@@ -1636,12 +1636,12 @@
                     <p class="desc-text" data-i18n="portfolio.legacy.p05.text">Solche Detailpunkte entscheiden über den hochwertigen Gesamteindruck einer Terrasse.</p>
                 </div>
                 <div class="project-request">
-                    <a class="btn btn-secondary btn-small" href="contact.html#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
+                    <a class="btn btn-secondary btn-small" href="contact.html?project=terrace#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
                     <span data-i18n="portfolio.request.note">Kurze Beschreibung genügt – wir melden uns persönlich.</span>
                 </div>
             </article>
 
-            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen balkon aussenbau">
+            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen balkon aussenbau" data-request-type="terrace">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.legacy.label">Ausgeführte Referenz</div>
@@ -1672,12 +1672,12 @@
                     <p class="desc-text" data-i18n="portfolio.legacy.p06.text">Die Dielen verleihen dem Balkon mehr Wärme und Nutzqualität, ohne die klare Architektur zu stören.</p>
                 </div>
                 <div class="project-request">
-                    <a class="btn btn-secondary btn-small" href="contact.html#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
+                    <a class="btn btn-secondary btn-small" href="contact.html?project=terrace#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
                     <span data-i18n="portfolio.request.note">Kurze Beschreibung genügt – wir melden uns persönlich.</span>
                 </div>
             </article>
 
-            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen balkon aussenbau">
+            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen balkon aussenbau" data-request-type="terrace">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.legacy.label">Ausgeführte Referenz</div>
@@ -1708,12 +1708,12 @@
                     <p class="desc-text" data-i18n="portfolio.legacy.p07.text">Die Fläche wirkt hochwertig und macht auch kleine Außenbereiche wohnlicher.</p>
                 </div>
                 <div class="project-request">
-                    <a class="btn btn-secondary btn-small" href="contact.html#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
+                    <a class="btn btn-secondary btn-small" href="contact.html?project=terrace#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
                     <span data-i18n="portfolio.request.note">Kurze Beschreibung genügt – wir melden uns persönlich.</span>
                 </div>
             </article>
 
-            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen balkon aussenbau">
+            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen balkon aussenbau" data-request-type="terrace">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.legacy.label">Ausgeführte Referenz</div>
@@ -1744,12 +1744,12 @@
                     <p class="desc-text" data-i18n="portfolio.legacy.p08.text">Die Aufnahme eignet sich gut, um Materialqualität, Fugenbild und präzise Ausführung sichtbar zu machen.</p>
                 </div>
                 <div class="project-request">
-                    <a class="btn btn-secondary btn-small" href="contact.html#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
+                    <a class="btn btn-secondary btn-small" href="contact.html?project=terrace#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
                     <span data-i18n="portfolio.request.note">Kurze Beschreibung genügt – wir melden uns persönlich.</span>
                 </div>
             </article>
 
-            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen aussenbau">
+            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen aussenbau" data-request-type="terrace">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.legacy.label">Ausgeführte Referenz</div>
@@ -1780,12 +1780,12 @@
                     <p class="desc-text" data-i18n="portfolio.legacy.p09.text">Die Ausführung verbindet praktische Nutzung mit einer warmen, hochwertigen Außenwirkung.</p>
                 </div>
                 <div class="project-request">
-                    <a class="btn btn-secondary btn-small" href="contact.html#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
+                    <a class="btn btn-secondary btn-small" href="contact.html?project=terrace#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
                     <span data-i18n="portfolio.request.note">Kurze Beschreibung genügt – wir melden uns persönlich.</span>
                 </div>
             </article>
 
-            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen aussenbau">
+            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen aussenbau" data-request-type="terrace">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.legacy.label">Ausgeführte Referenz</div>
@@ -1816,12 +1816,12 @@
                     <p class="desc-text" data-i18n="portfolio.legacy.p10.text">Das helle Holz und die ruhige Form schaffen einen freundlichen, gepflegten Eindruck.</p>
                 </div>
                 <div class="project-request">
-                    <a class="btn btn-secondary btn-small" href="contact.html#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
+                    <a class="btn btn-secondary btn-small" href="contact.html?project=terrace#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
                     <span data-i18n="portfolio.request.note">Kurze Beschreibung genügt – wir melden uns persönlich.</span>
                 </div>
             </article>
 
-            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen aussenbau">
+            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen aussenbau" data-request-type="terrace">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.legacy.label">Ausgeführte Referenz</div>
@@ -1852,12 +1852,12 @@
                     <p class="desc-text" data-i18n="portfolio.legacy.p11.text">Die dunklere Holzfarbe setzt einen starken Akzent zur hellen Fassade und zum Garten.</p>
                 </div>
                 <div class="project-request">
-                    <a class="btn btn-secondary btn-small" href="contact.html#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
+                    <a class="btn btn-secondary btn-small" href="contact.html?project=terrace#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
                     <span data-i18n="portfolio.request.note">Kurze Beschreibung genügt – wir melden uns persönlich.</span>
                 </div>
             </article>
 
-            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen aussenbau">
+            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen aussenbau" data-request-type="terrace">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.legacy.label">Ausgeführte Referenz</div>
@@ -1888,12 +1888,12 @@
                     <p class="desc-text" data-i18n="portfolio.legacy.p12.text">Die Stufenausbildung verbindet Gestaltung, Komfort und robuste Alltagstauglichkeit.</p>
                 </div>
                 <div class="project-request">
-                    <a class="btn btn-secondary btn-small" href="contact.html#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
+                    <a class="btn btn-secondary btn-small" href="contact.html?project=terrace#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
                     <span data-i18n="portfolio.request.note">Kurze Beschreibung genügt – wir melden uns persönlich.</span>
                 </div>
             </article>
 
-            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen innenausbau aussenbau">
+            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen innenausbau aussenbau" data-request-type="outdoor">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.legacy.label">Ausgeführte Referenz</div>
@@ -1924,12 +1924,12 @@
                     <p class="desc-text" data-i18n="portfolio.legacy.p13.text">Die Kombination aus Terrassenfläche und Fassadendetail wirkt architektonisch und sehr hochwertig.</p>
                 </div>
                 <div class="project-request">
-                    <a class="btn btn-secondary btn-small" href="contact.html#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
+                    <a class="btn btn-secondary btn-small" href="contact.html?project=outdoor#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
                     <span data-i18n="portfolio.request.note">Kurze Beschreibung genügt – wir melden uns persönlich.</span>
                 </div>
             </article>
 
-            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen innenausbau aussenbau">
+            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen innenausbau aussenbau" data-request-type="outdoor">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.legacy.label">Ausgeführte Referenz</div>
@@ -1960,12 +1960,12 @@
                     <p class="desc-text" data-i18n="portfolio.legacy.p14.text">Die Wandverkleidung schafft Sichtschutz, Struktur und eine klare Verbindung zur Terrasse.</p>
                 </div>
                 <div class="project-request">
-                    <a class="btn btn-secondary btn-small" href="contact.html#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
+                    <a class="btn btn-secondary btn-small" href="contact.html?project=outdoor#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
                     <span data-i18n="portfolio.request.note">Kurze Beschreibung genügt – wir melden uns persönlich.</span>
                 </div>
             </article>
 
-            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen innenausbau aussenbau">
+            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen innenausbau aussenbau" data-request-type="outdoor">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.legacy.label">Ausgeführte Referenz</div>
@@ -1996,12 +1996,12 @@
                     <p class="desc-text" data-i18n="portfolio.legacy.p15.text">Die präzisen Anschlüsse zeigen, wie wichtig Planung und saubere Montage bei Außenverkleidungen sind.</p>
                 </div>
                 <div class="project-request">
-                    <a class="btn btn-secondary btn-small" href="contact.html#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
+                    <a class="btn btn-secondary btn-small" href="contact.html?project=outdoor#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
                     <span data-i18n="portfolio.request.note">Kurze Beschreibung genügt – wir melden uns persönlich.</span>
                 </div>
             </article>
 
-            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen innenausbau aussenbau">
+            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen innenausbau aussenbau" data-request-type="outdoor">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.legacy.label">Ausgeführte Referenz</div>
@@ -2032,12 +2032,12 @@
                     <p class="desc-text" data-i18n="portfolio.legacy.p16.text">Die klare rechteckige Fläche wirkt aufgeräumt und eignet sich sehr gut für Sitzgruppe und Alltag.</p>
                 </div>
                 <div class="project-request">
-                    <a class="btn btn-secondary btn-small" href="contact.html#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
+                    <a class="btn btn-secondary btn-small" href="contact.html?project=outdoor#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
                     <span data-i18n="portfolio.request.note">Kurze Beschreibung genügt – wir melden uns persönlich.</span>
                 </div>
             </article>
 
-            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen innenausbau aussenbau">
+            <article class="project-card legacy-reference-card" data-category="terrassen" data-categories="terrassen innenausbau aussenbau" data-request-type="outdoor">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.legacy.label">Ausgeführte Referenz</div>
@@ -2068,12 +2068,12 @@
                     <p class="desc-text" data-i18n="portfolio.legacy.p17.text">Das Bild zeigt, wie Holz, Licht und lange Linien einen Außenbereich besonders hochwertig wirken lassen.</p>
                 </div>
                 <div class="project-request">
-                    <a class="btn btn-secondary btn-small" href="contact.html#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
+                    <a class="btn btn-secondary btn-small" href="contact.html?project=outdoor#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
                     <span data-i18n="portfolio.request.note">Kurze Beschreibung genügt – wir melden uns persönlich.</span>
                 </div>
             </article>
 
-            <article class="project-card legacy-reference-card" data-category="moebel" data-categories="moebel aussenbau">
+            <article class="project-card legacy-reference-card" data-category="moebel" data-categories="moebel aussenbau" data-request-type="outdoor">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.legacy.label">Ausgeführte Referenz</div>
@@ -2104,12 +2104,12 @@
                     <p class="desc-text" data-i18n="portfolio.legacy.p18.text">Die Verkleidung wertet technische oder funktionale Elemente sichtbar auf und fügt sie in die Außenanlage ein.</p>
                 </div>
                 <div class="project-request">
-                    <a class="btn btn-secondary btn-small" href="contact.html#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
+                    <a class="btn btn-secondary btn-small" href="contact.html?project=outdoor#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
                     <span data-i18n="portfolio.request.note">Kurze Beschreibung genügt – wir melden uns persönlich.</span>
                 </div>
             </article>
 
-            <article class="project-card legacy-reference-card" data-category="innenausbau" data-categories="aussenbau">
+            <article class="project-card legacy-reference-card" data-category="innenausbau" data-categories="aussenbau" data-request-type="outdoor">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.legacy.label">Ausgeführte Referenz</div>
@@ -2140,12 +2140,12 @@
                     <p class="desc-text" data-i18n="portfolio.legacy.p19.text">Die Holzoberfläche und die reduzierte Ausführung passen gut in Garten- und Außenbereiche.</p>
                 </div>
                 <div class="project-request">
-                    <a class="btn btn-secondary btn-small" href="contact.html#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
+                    <a class="btn btn-secondary btn-small" href="contact.html?project=outdoor#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
                     <span data-i18n="portfolio.request.note">Kurze Beschreibung genügt – wir melden uns persönlich.</span>
                 </div>
             </article>
 
-            <article class="project-card legacy-reference-card" data-category="moebel" data-categories="kuechen moebel innenausbau">
+            <article class="project-card legacy-reference-card" data-category="moebel" data-categories="kuechen moebel innenausbau" data-request-type="kitchen">
                 <div class="project-card-header">
                     <div>
                         <div class="project-label" data-i18n="portfolio.legacy.label">Ausgeführte Referenz</div>
@@ -2176,7 +2176,7 @@
                     <p class="desc-text" data-i18n="portfolio.legacy.p20.text">Die Küche zeigt, dass EF-Sinn nicht nur Außenbereiche, sondern auch hochwertige Innenausbauten und Küchen umsetzt.</p>
                 </div>
                 <div class="project-request">
-                    <a class="btn btn-secondary btn-small" href="contact.html#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
+                    <a class="btn btn-secondary btn-small" href="contact.html?project=kitchen#anfrage-assistent" data-i18n="portfolio.request.similar">Ähnliches Projekt anfragen</a>
                     <span data-i18n="portfolio.request.note">Kurze Beschreibung genügt – wir melden uns persönlich.</span>
                 </div>
             </article>
@@ -2355,14 +2355,14 @@
         </div>
     </footer>
 
-    <script src="assets/js/i18n.js?v=20260609b"></script>
+    <script src="assets/js/i18n.js?v=20260609c"></script>
     <script>
     /* ===== Portfolio Page Interactions ===== */
     (function() {
         'use strict';
 
-        /* --- Fixed Category Select --- */
-        var categorySelect = document.getElementById('portfolio-category-select');
+        /* --- Fixed Category Buttons --- */
+        var categoryBtns = document.querySelectorAll('.portfolio-category-btn[data-filter]');
         var projectCards = document.querySelectorAll('.project-card[data-category], .project-card[data-categories]');
         var countEl = document.getElementById('visible-count');
         var activeFilter = 'all';
@@ -2371,8 +2371,16 @@
             return (card.getAttribute('data-categories') || card.getAttribute('data-category') || '').split(/\s+/).filter(Boolean);
         }
 
+        function setActiveFilter(filter) {
+            activeFilter = filter || 'all';
+            categoryBtns.forEach(function(btn) {
+                var isActive = btn.getAttribute('data-filter') === activeFilter;
+                btn.classList.toggle('active', isActive);
+                btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+            });
+        }
+
         function applyFilters() {
-            activeFilter = categorySelect ? categorySelect.value : 'all';
             var visible = 0;
             projectCards.forEach(function(card) {
                 var categories = cardCategories(card);
@@ -2387,10 +2395,14 @@
             if (countEl) countEl.textContent = visible;
         }
 
-        if (categorySelect) {
-            categorySelect.addEventListener('change', applyFilters);
-        }
+        categoryBtns.forEach(function(btn) {
+            btn.addEventListener('click', function() {
+                setActiveFilter(btn.getAttribute('data-filter'));
+                applyFilters();
+            });
+        });
 
+        setActiveFilter('all');
         applyFilters();
 
         /* --- Scroll Reveal (Intersection Observer) --- */

--- a/styles.css
+++ b/styles.css
@@ -50,8 +50,8 @@ html {
 }
 
 body {
-    font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', 
-                 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Helvetica Neue', 
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+                 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Helvetica Neue',
                  Arial, sans-serif;
     line-height: 1.6;
     color: #2c2c2c;
@@ -94,22 +94,22 @@ textarea {
     --color-background: #ffffff;     /* Weiß */
     --color-background-alt: #f4f5f7; /* Kühles Hellgrau */
     --color-border: #d8d8da;         /* Silber (Logo-Stahl) */
-    
+
     /* Abstände */
     --spacing-xs: 0.5rem;
     --spacing-sm: 1rem;
     --spacing-md: 2rem;
     --spacing-lg: 4rem;
     --spacing-xl: 6rem;
-    
+
     /* Container */
     --container-width: 1200px;
     --container-padding: 2rem;
-    
+
     /* Transitions */
     --transition-speed: 0.3s;
     --transition-timing: cubic-bezier(0.4, 0, 0.2, 1);
-    
+
     /* Shadows */
     --shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.1);
     --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.15);
@@ -211,7 +211,7 @@ textarea {
         animation-iteration-count: 1 !important;
         transition-duration: 0.01ms !important;
     }
-    
+
     html {
         scroll-behavior: auto;
     }
@@ -314,7 +314,7 @@ textarea {
     left: 0;
     right: 0;
     bottom: 0;
-    background-image: 
+    background-image:
         radial-gradient(circle at 20% 80%, rgba(212, 160, 16, 0.15) 0%, transparent 50%),
         radial-gradient(circle at 80% 20%, rgba(60, 200, 240, 0.1) 0%, transparent 50%);
     opacity: 1;
@@ -1852,11 +1852,11 @@ img {
     .nav-link {
         padding: 0.25rem 0.2rem;
     }
-    
+
     .hero {
         min-height: 500px;
     }
-    
+
     .intro-grid,
     .about-grid,
     .contact-grid,
@@ -1866,7 +1866,7 @@ img {
         grid-template-columns: 1fr;
         gap: var(--spacing-md);
     }
-    
+
     .services-grid,
     .values-grid,
     .strength-grid {
@@ -1896,7 +1896,7 @@ img {
         margin: -2rem 1rem 0;
         width: auto;
     }
-    
+
     .portfolio-grid {
         grid-template-columns: 1fr;
     }
@@ -1904,17 +1904,17 @@ img {
         grid-column: span 1;
         grid-row: span 1;
     }
-    
+
     .process-timeline::before {
         left: 20px;
     }
-    
+
     .timeline-marker {
         width: 40px;
         height: 40px;
         font-size: 1.125rem;
     }
-    
+
     .footer-grid {
         grid-template-columns: 1fr;
     }
@@ -1961,19 +1961,19 @@ img {
     .service-detail-header {
         padding: 15rem 0 2.5rem;
     }
-    
+
     .logo a {
         font-size: 1.25rem;
     }
-    
+
     .hero-title {
         font-size: 2rem;
     }
-    
+
     .hero-subtitle {
         font-size: 1rem;
     }
-    
+
     .btn {
         padding: 0.875rem 1.5rem;
     }
@@ -1988,12 +1988,12 @@ img {
     .scroll-indicator {
         display: none;
     }
-    
+
     body {
         color: black;
         background: white;
     }
-    
+
     .hero {
         page-break-after: always;
     }
@@ -2113,7 +2113,7 @@ img {
         --color-text: #000000;
         --color-border: #333333;
     }
-    
+
     .btn {
         border-width: 3px;
     }
@@ -2299,6 +2299,33 @@ img {
     color: var(--color-primary);
 }
 
+
+.portfolio-category-buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.55rem;
+}
+
+.portfolio-category-btn {
+    border: 1px solid var(--color-border);
+    border-radius: 999px;
+    padding: 0.55rem 0.95rem;
+    background: var(--color-background-alt);
+    color: var(--color-text);
+    cursor: pointer;
+    font-weight: 700;
+    font: inherit;
+    transition: all 0.2s ease;
+}
+
+.portfolio-category-btn:hover,
+.portfolio-category-btn:focus,
+.portfolio-category-btn.active {
+    border-color: var(--color-primary);
+    color: white;
+    background: var(--color-primary);
+}
+
 .project-request {
     margin-top: 1.25rem;
     padding-top: 1rem;
@@ -2377,7 +2404,34 @@ img {
         color: var(--color-primary-dark);
     }
 
-    .project-request {
+
+.portfolio-category-buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.55rem;
+}
+
+.portfolio-category-btn {
+    border: 1px solid var(--color-border);
+    border-radius: 999px;
+    padding: 0.55rem 0.95rem;
+    background: var(--color-background-alt);
+    color: var(--color-text);
+    cursor: pointer;
+    font-weight: 700;
+    font: inherit;
+    transition: all 0.2s ease;
+}
+
+.portfolio-category-btn:hover,
+.portfolio-category-btn:focus,
+.portfolio-category-btn.active {
+    border-color: var(--color-primary);
+    color: white;
+    background: var(--color-primary);
+}
+
+.project-request {
         align-items: stretch;
     }
 


### PR DESCRIPTION
## Zusammenfassung
- ersetzt die Kategorie-Auswahl im Portfolio durch eine feste Button-Reihe: ein Button pro Kategorie, keine freie Texteingabe, keine zweite Kategorie-Leiste
- behält die Mehrfach-Kategorien pro Referenz, damit passende Projekte vollständig in den Kategorien erscheinen
- verknüpft jeden „Ähnliches Projekt anfragen“-Button mit einer passenden Projektart für die Schnelle Projektanfrage
- ergänzt im Anfrage-Assistenten die Projektart „Außenbau / Gartenhaus“ und liest `?project=...` aus Portfolio-Links aus
- aktualisiert Übersetzungen für DE, EN, FR, EL, IT, ES und DE-AT

## Prüfung
- `node -c assets/js/i18n.js`
- `git diff --check`
- i18n-Key-Coverage für alle verwendeten `data-i18n*`-Keys
- lokale Firefox/WebDriver-Prüfung in allen 7 Sprachen: 8 Kategorie-Buttons, keine freie Texteingabe, keine doppelte Button-Leiste, korrekte Kategorie-Zählung
- lokale Kontaktprüfung: `?project=stairs`, `?project=outdoor`, `?project=kitchen`, `?project=parquetInstall`, `?project=bathroomFurniture` aktivieren die passende Projektart im Anfrage-Assistenten
